### PR TITLE
Fix broken translate attributes

### DIFF
--- a/app/includes/dao.tpl
+++ b/app/includes/dao.tpl
@@ -61,7 +61,7 @@
           <a class="btn btn-danger btn-lg" data-toggle="modal" data-target="#withdrawTransaction" translate="DAO_TitleLong">
             WITHDRAW YOUR DAO TOKENS FOR ETH
           </a>
-          <p><small> Yes. Just push the big red button. It's that easy. </small></p>
+          <p><small translate="DAO_Inst"> Yes. Just push the big red button. It's that easy. </small></p>
           <div class="form-group col-xs-12" ng-bind-html="sendTxStatus"></div>
           <div class="form-group col-xs-12" ng-bind-html="withdrawTxStatus"></div>
         </div>

--- a/app/includes/digix.tpl
+++ b/app/includes/digix.tpl
@@ -98,7 +98,7 @@
       </div>
 
       <div class="form-group col-xs-12" ng-show="showRaw">
-        <a class="btn btn-primary btn-block" data-toggle="modal" data-target="#sendTransaction" translate="SEND_generate">Generate Signed Transaction</a>
+        <a class="btn btn-primary btn-block" data-toggle="modal" data-target="#sendTransaction" translate="SEND_trans">Send Transaction</a>
       </div>
 
       <div class="form-group col-xs-12" ng-bind-html="sendTxStatus"></div>

--- a/app/includes/help.tpl
+++ b/app/includes/help.tpl
@@ -141,7 +141,7 @@
 
   @@if (site === 'mew' ) {
   <h4 translate="HELP_5_Title">5. How do I run MyEtherWallet.com offline/locally? </h4>
-  <p tranlsate="HELP_5_Desc_1"> You can run MyEtherWallet.com on your computer instead of from the GitHub servers. You can generatea a wallet completely offline and send transactions from the "Offline Transaction" page. </p>
+  <p translate="HELP_5_Desc_1"> You can run MyEtherWallet.com on your computer instead of from the GitHub servers. You can generatea a wallet completely offline and send transactions from the "Offline Transaction" page. </p>
   <ol>
     <li translate="HELP_5_Desc_2">Go to our github: <a href="https://github.com/kvhnuke/etherwallet/tree/gh-pages">https://github.com/kvhnuke/etherwallet/tree/gh-pages</a>.</li>
     <li translate="HELP_5_Desc_3">Click download zip in the upper right.</li>


### PR DESCRIPTION
Hi,
this is a very small patch to fix some translations not appearing due to incorrect translate attributes. Furthermore I changed "Generate Signed Transaction" to "Send Transaction" in DGD page (because signed transaction was already generated, that button is used to send the transaction). Before the translations, it read "EXECUTE TRANSACTION"
