### PR TITLE
Support for translating Geth error messages

### DIFF
--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -43,9 +43,19 @@ var tabsCtrl = function($scope, globalService, $translate) {
 		for (var i = 0; i < globalFuncs.errorMsgs.length; i++) $scope.setLanguageVal('ERROR_' + (i + 1), 'errorMsgs', i);
 		for (var i = 0; i < globalFuncs.successMsgs.length; i++) $scope.setLanguageVal('SUCCESS_' + (i + 1), 'successMsgs', i);
 	}
+	$scope.setGethErrMsgLanguage = function() {
+		globalFuncs.gethErrorMsgs = {};
+		for (var s in globalFuncs.gethErrors) {
+			var key = globalFuncs.gethErrors[s];
+			if (key.indexOf("GETH_") === 0) {
+				$scope.setLanguageVal(key,'gethErrorMsgs',key);
+			}
+		}
+	}
 	$scope.changeLanguage = function(key, value) {
 		$translate.use(key);
 		$scope.setErrorMsgLanguage();
+		$scope.setGethErrMsgLanguage();
 		$scope.curLang = value;
 		$scope.setArrowVisibility();
 		$scope.dropdown = false;

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -55,6 +55,26 @@ globalFuncs.successMsgs = [
 	"Transaction submitted. TX ID: ",
 	"Your wallet was successfully added: ",
 	"You have successfully voted. Thank you for being an active participant in The DAO."];
+globalFuncs.gethErrors = {
+        "Invalid sender": "GETH_InvalidSender",
+        "Nonce too low": "GETH_Nonce",
+        "Gas price too low for acceptance": "GETH_Cheap",
+        "Insufficient balance": "GETH_Balance",
+        "Account does not exist or account balance too low": "GETH_NonExistentAccount",
+        "Insufficient funds for gas * price + value": "GETH_InsufficientFunds",
+        "Intrinsic gas too low": "GETH_IntrinsicGas",
+        "Exceeds block gas limit": "GETH_GasLimit",
+        "Negative value": "GETH_NegativeValue"};
+globalFuncs.gethErrorMsgs = {};
+globalFuncs.getGethMsg = function(str) {
+	if (str in this.gethErrors) {
+		var key = this.gethErrors[str];
+		if (key in this.gethErrorMsgs) {
+			return this.gethErrorMsgs[key];
+		}
+	}
+	return str;
+}
 globalFuncs.scrypt = {
 	n: 1024
 };

--- a/app/scripts/translations/en.js
+++ b/app/scripts/translations/en.js
@@ -259,6 +259,17 @@ en.data = {
   SUCCESS_4:            'Your wallet was successfully added: ',
   SUCCESS_5:            'You have successfully voted. Thank you for being an active participant in The DAO.',
 
+  /* Geth Error Messages */
+  GETH_InvalidSender:      'Invalid sender',
+  GETH_Nonce:              'Nonce too low',
+  GETH_Cheap:              'Gas price too low for acceptance',
+  GETH_Balance:            'Insufficient balance',
+  GETH_NonExistentAccount: 'Account does not exist or account balance too low',
+  GETH_InsufficientFunds:  'Insufficient funds for gas * price + value',
+  GETH_IntrinsicGas:       'Intrinsic gas too low',
+  GETH_GasLimit:           'Exceeds block gas limit',
+  GETH_NegativeValue:      'Negative value',
+
   /* Tranlsation Info */
   translate_version:    '0.3',
   Translator_Desc:      '',

--- a/app/scripts/translations/it.js
+++ b/app/scripts/translations/it.js
@@ -260,6 +260,17 @@ it.data = {
   SUCCESS_4:            'Il portafoglio è stato aggiunto correttamente: ',
   SUCCESS_5:            'Hai votato con successo. Grazie per essere un partecipante attivo in The DAO.',
 
+  /* Geth Error Messages */
+  GETH_InvalidSender:      'Mittente non valido',
+  GETH_Nonce:              'Nonce troppo basso',
+  GETH_Cheap:              'Prezzo del gas troppo basso per essere accettato',
+  GETH_Balance:            'Saldo insufficiente',
+  GETH_NonExistentAccount: 'Il conto non esiste o il saldo è insufficiente',
+  GETH_InsufficientFunds:  'Fondi insufficienti per gas * prezzo + valore',
+  GETH_IntrinsicGas:       'Gas intrinseco troppo basso',
+  GETH_GasLimit:           'Eccede il limite gas per il blocco',
+  GETH_NegativeValue:      'Valore negativo',
+
   /* Tranlsation Info */
   translate_version:    '0.3',
   Translator_Desc:      'Grazie ai nostri traduttori: ',

--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -48,7 +48,7 @@ uiFuncs.sendClassicTx = function(signedTx, callback) {
 		if (data.error) {
 			resp = {
 				isError: true,
-				error: data.msg
+				error: globalFuncs.getGethMsg(data.msg)
 			};
 		} else {
 			resp = {
@@ -96,7 +96,7 @@ uiFuncs.sendTx = function(signedTx, callback) {
 		if (data.error) {
 			resp = {
 				isError: true,
-				error: data.msg
+				error: globalFuncs.getGethMsg(data.msg)
 			};
 		} else {
 			resp = {


### PR DESCRIPTION
- Added support for translating Geth error messages via double lookup
- ATM, only transaction-related messages (from go-ethereum/core/tx_pool.go) are provided, but it might be enough.
- Added Italian translations for those messages
