### PR TITLE
Add imToken to the Mnemonic supports list.

### DIFF
--- a/app/scripts/translations/de.js
+++ b/app/scripts/translations/de.js
@@ -19,7 +19,7 @@ de.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   TOKEN_show:           'Show All Tokens',

--- a/app/scripts/translations/el.js
+++ b/app/scripts/translations/el.js
@@ -19,7 +19,7 @@ el.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   TOKEN_show:           'Show All Tokens',

--- a/app/scripts/translations/en.js
+++ b/app/scripts/translations/en.js
@@ -42,7 +42,7 @@ en.data = {
   x_Keystore:           'Keystore File (UTC / JSON · Recommended · Encrypted · Mist Format)',
   x_Keystore2:          'Keystore File (UTC / JSON)',
   x_KeystoreDesc:       'This Keystore file matches the format used by Mist so you can easily import it in the future. It is the recommended file to download and back up.',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'Password',
   x_Print:              'Print Paper Wallet',
   x_PrintDesc:          'ProTip: Click print and save this as a PDF, even if you do not own a printer!',

--- a/app/scripts/translations/es.js
+++ b/app/scripts/translations/es.js
@@ -24,7 +24,7 @@ es.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   ERROR_21:             ' is not a valid ERC-20 token. If other tokens are loading, please remove this token and try again.',

--- a/app/scripts/translations/fi.js
+++ b/app/scripts/translations/fi.js
@@ -21,7 +21,7 @@ fi.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   ERROR_21:             ' is not a valid ERC-20 token. If other tokens are loading, please remove this token and try again.',

--- a/app/scripts/translations/fr.js
+++ b/app/scripts/translations/fr.js
@@ -43,7 +43,7 @@ fr.data = {
   x_Keystore:           'Fichier Keystore (UTC / JSON · Recommandé · Chiffré · Format Mist)',
   x_KeystoreDesc:       'Ce fichier Keystore utilise le même format que celui que Mist, vous pouvez donc facilement l\'importer plus tard dans ces logiciels. C\'est le fichier que nous vous recommandons de télécharger et sauvegarder.',
   x_Ledger:             'Ledger Nano S',
-  x_Mnemonic:           'Phrase mnémonique (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Phrase mnémonique (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'Mot de passe',
   x_Print:              'Imprimer un portefeuille papier',
   x_PrintDesc:          'Astuce : Cliquez sur Imprimer et sauvegardez le portefeuille papier comme un PDF, même si vous n\'avez pas d\'imprimante !',

--- a/app/scripts/translations/hu.js
+++ b/app/scripts/translations/hu.js
@@ -49,7 +49,7 @@ hu.data = {
   x_Keystore:           'Keystore Fájl (UTC / JSON · Ajánlott · Titkosított · Mist Formátum)',
   x_Keystore2:          'Keystore Fájl (UTC / JSON)',
   x_KeystoreDesc:       'Ez a Keystore fájl ugyanolyan formátumú, amit a Mist használ, tehát könnyedén importálhatod a későbbiekben. Leginkább ezt a fájlt ajánlott letölteni és elmenteni.',
-  x_Mnemonic:           'Mnemonikus frázis (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonikus frázis (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'Jelszó',
   x_Print:              'PapírTárca Nyomtatása ',
   x_PrintDesc:          'Profi Tipp: Kattints a nyomtatásra és mentsd el PDF formátumban, még abban az esetben is, ha nincs nyomtatód!',

--- a/app/scripts/translations/id.js
+++ b/app/scripts/translations/id.js
@@ -43,7 +43,7 @@ id.data = {
   x_Keystore:           'File Keystore (UTC / JSON · Format yang direkomendasikan · Ter-enkripsi · Format Mist)',
   x_KeystoreDesc:       'File Keystore ini sesuai dengan format yang dipakai Mist sehingga memudahkan untuk diimpor di kemudian hari. File ini yang disarankan untuk di unduh dan di backup.',
   x_Ledger:             'Ledger Nano S',
-  x_Mnemonic:           '"Mnemonic Phrase" (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           '"Mnemonic Phrase" (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'Password',
   x_Print:              'Print Dompet Kertas',
   x_PrintDesc:          'ProTip: klik print dan simpan sebagai PDF jika Anda tidak memiliki printer!',

--- a/app/scripts/translations/it.js
+++ b/app/scripts/translations/it.js
@@ -45,7 +45,7 @@ it.data = {
   x_Keystore:           'File Keystore (UTC / JSON · Consigliato · Crittografato · Formato Mist)',
   x_Keystore2:          'File Keystore (UTC / JSON)',
   x_KeystoreDesc:       'Questo file Keystore è compatibile con il formato usato da Mist, in modo da poterlo facilmente importare in futuro. È il file consigliato da scaricare e conservare.',
-  x_Mnemonic:           'Frase mnemonica (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Frase mnemonica (MetaMask / Jaxx / ether.cards / imToken)',
   x_Json:               'File JSON (non crittografato)',
   x_JsonDesc:           'Questa è la tua chiave privata in formato JSON non crittografato. Significa che non hai bisogno della password, ma chiunque trovi questo file JSON potrà avere accesso al tuo portafoglio e ai tuoi ether senza password.',
   x_PrintShort:         'Stampa',

--- a/app/scripts/translations/ja.js
+++ b/app/scripts/translations/ja.js
@@ -53,7 +53,7 @@ ja.data = {
   x_Keystore:           'Keystore ファイル (UTC / JSON · 推奨 · 暗号化 · Mist フォーマット)',
   x_Keystore2:          'Keystore ファイル (UTC / JSON) ',
   x_KeystoreDesc:       'この Keystore / JSON ファイルは、後で容易にインポートするため、Mistで使われているフォーマットと一致させる必要があります。ダウンロードしてバックアップを取ることをおすすめします。',
-  x_Mnemonic:           'ニーモニックフレーズ (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'ニーモニックフレーズ (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'パスワード',
   x_Print:              'ペーパーウォレットを印刷',
   x_PrintDesc:          'ProTip: プリンターが接続されていなくても、「印刷」をクリックしてPDFで保存できます。',

--- a/app/scripts/translations/nl.js
+++ b/app/scripts/translations/nl.js
@@ -33,7 +33,7 @@ nl.data = {
   x_Keystore:           'Keystore Bestand (UTC / JSON · Aangeraden · versleuteld · Mist Formaat)',
   x_Keystore2:          'Keystore Bestand (UTC / JSON) ',
   x_KeystoreDesc:       'Dit Keystore bestand voldoen aan het formaat zoals gebruikt door Mist waardoor je het gemakkelijk kunt importeren in de toekomst. Dit is de aanbevolen methode voor download en back up.',
-  x_Mnemonic:           'Mnemonic Zin (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Zin (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'Wachtwoord',
   x_Print:              'Druk je papieren wallet af',
   x_PrintDesc:          'ProTip: Klik Afdrukken en sla deze pagina op als PDF, zelfs als je geen printer hebt!',

--- a/app/scripts/translations/no.js
+++ b/app/scripts/translations/no.js
@@ -21,7 +21,7 @@ no.data = {
   MNEM_2:               'Din "HD-mnemoniske frase" kan gi deg tilgang til flere lommebøker / adresser. Vennligst velg den adressen du vil jobbe med denne gangen.',
   MNEM_more:            'Flere Adresser',
   MNEM_prev:            'Forrige Adresse',
-  x_Mnemonic:           'Mnemonisk Frase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonisk Frase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Lim inn/tast din mnemoniske frase',
   SEND_custom:          'Legg til Token',
   ERROR_21:             ' er ikke en gyldig ERC-20-token. Hvis andre tokens holder på å lastes, vennligst fjern denne token og prøv igjen.',

--- a/app/scripts/translations/pl.js
+++ b/app/scripts/translations/pl.js
@@ -40,7 +40,7 @@ pl.data = {
   x_Keystore:           'Plik Keystore (UTC / JSON · Zalecany · Szyfrowany · Format Mist)',
   x_Keystore2:          'Plik Keystore (UTC / JSON) ',
   x_KeystoreDesc:       'Ten plik Keystore odpowiada formatowi stosowanemu przez Mist, więc może być w prosty sposób zaimportowany w przyszłości. Jest to zalecana forma pliku do pobrania i przechowywania jako kopii zapasowej.',
-  x_Mnemonic:           'Mnemonik (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonik (MetaMask / Jaxx / ether.cards / imToken)',
   x_Json:               'Plik JSON (nieszyfrowany)',
   x_JsonDesc:           'Nieszyfrowany klucz prywatny, plik w formacie JSON. Nie wymaga podania hasła, ale każdy kto zdobędzie ten plik uzyska również pełny dostęp do Twojego portfela i zgromadzonych na nim środków.',
   x_PrintShort:         'Drukuj',

--- a/app/scripts/translations/pt.js
+++ b/app/scripts/translations/pt.js
@@ -48,7 +48,7 @@ pt.data = {
   x_Keystore:           'Arquivo de armazenamento de chaves (UTC / JSON · Recomendado · Criptografado · Formato Mist)',
   x_Keystore2:          'Arquivo de armazenamento de chaves (UTC / JSON)',
   x_KeystoreDesc:       'Este arquivo de armazenamento de chaves corresponde ao formato usado pela Mist para que você possa facilmente importá-lo no futuro. É recomendado que o arquivo seja transferido e feito seu backup.',
-  x_Mnemonic:           'Frase Mnemonic (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Frase Mnemonic (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'Senha',
   x_Print:              'Imprimir Carteira de Papel',
   x_PrintDesc:          'Dica: Clique impressão e salve como PDF, mesmo se você não possui uma impressora!',

--- a/app/scripts/translations/ru.js
+++ b/app/scripts/translations/ru.js
@@ -22,7 +22,7 @@ ru.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   ERROR_21:             ' is not a valid ERC-20 token. If other tokens are loading, please remove this token and try again.',

--- a/app/scripts/translations/sl.js
+++ b/app/scripts/translations/sl.js
@@ -21,7 +21,7 @@ sl.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   ERROR_21:             ' is not a valid ERC-20 token. If other tokens are loading, please remove this token and try again.',

--- a/app/scripts/translations/sv.js
+++ b/app/scripts/translations/sv.js
@@ -21,7 +21,7 @@ sv.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   ERROR_21:             ' is not a valid ERC-20 token. If other tokens are loading, please remove this token and try again.',

--- a/app/scripts/translations/tr.js
+++ b/app/scripts/translations/tr.js
@@ -21,7 +21,7 @@ tr.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   ERROR_21:             ' is not a valid ERC-20 token. If other tokens are loading, please remove this token and try again.',

--- a/app/scripts/translations/vi.js
+++ b/app/scripts/translations/vi.js
@@ -55,7 +55,7 @@ vi.data = {
   x_Keystore:           'Định Dạng Keystore (UTC / JSON) (Đã mã hoá. Định Dạng này sử dụng cho Mist)',
   x_Keystore2:          'Định Dạng Keystore (UTC / JSON)',
   x_KeystoreDesc:       'Định dạng Keystore là tập một tin chứa dữ liệu ví đã được mã hoá của Private Key và sử dụng cho Mist. Do đó bạn có thể dễ dàng bỏ nó vào bên trong Mist và tiếp tục sử dụng ví của bạn. Đây là một tập tin được đề xuất nhằm sao lưu dữ liệu ví cá nhân.',
-  x_Mnemonic:           'Cụm từ dễ nhớ (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Cụm từ dễ nhớ (MetaMask / Jaxx / ether.cards / imToken)',
   x_Password:           'Mật Khẩu',
   x_Print:              'Tạo Ví Giấy',
   x_PrintDesc:          'Mẹo: kích chuột trái vào nút "In Ví" sau đó chọn "Save this as a PDF" đễ lưu nó thành định dạng PDF trên máy tính của bạn nếu bạn không sở hữu máy in cá nhân!',

--- a/app/scripts/translations/zh.js
+++ b/app/scripts/translations/zh.js
@@ -21,7 +21,7 @@ zh.data = {
   MNEM_2:               'Your single HD mnemonic phrase can access a number of wallets / addresses. Please select the address you would like to interact with at this time.',
   MNEM_more:            'More Addresses',
   MNEM_prev:            'Previous Addresses',
-  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards)',
+  x_Mnemonic:           'Mnemonic Phrase (MetaMask / Jaxx / ether.cards / imToken)',
   ADD_Radio_5:          'Paste/Type Your Mnemonic',
   SEND_custom:          'Add Custom Token',
   ERROR_21:             ' is not a valid ERC-20 token. If other tokens are loading, please remove this token and try again.',


### PR DESCRIPTION
imToken follows EIP84, the HDPath is m/44'/60'/0'/0/index, and uses the same wordlist. So user can export/import Mnemonic Phrase between imToken and MEW.

Test vector as:
```
{
Mnemonic: 'pond piano permit collect loan gym donor cabbage garment have mistake action'
address: '0xfe5afc729aae1ef38fc1213f31f1b54342cdbff9'
}
```