### PR TITLE
Fix issue #487 - custom chain id is stored as String instead of Integer

### DIFF
--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -80,7 +80,7 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
         else if (nodeInfo.options == 'cus') {
             tempObj = JSON.parse(JSON.stringify(nodes.customNodeObj));
             tempObj.eip155 = nodeInfo.eip155;
-            tempObj.chainId = nodeInfo.chainId;
+            tempObj.chainId = parseInt(nodeInfo.chainId);
         }
         if (tempObj) {
             tempObj.name = nodeInfo.name + ':' + nodeInfo.options;


### PR DESCRIPTION
fix #487 

To reproduce, click "Add Custom Node"
enter:
Node Name: whatever
URL: https://api.myetherapi.com/rop (for example)
Custom: ✓
Supports EIP-155: ✓
Chain ID: 3

Send a transaction

Without this change:
![screen shot 2017-05-24 at 11 08 37 pm](https://cloud.githubusercontent.com/assets/307119/26438443/f19a5338-40d7-11e7-819f-9332f32f9244.png)
With this change:
![screen shot 2017-05-24 at 11 09 47 pm](https://cloud.githubusercontent.com/assets/307119/26438448/f8ca2fac-40d7-11e7-95a3-9cf9c614b10f.png)