### PR TITLE
Store and show notifications in a more robust way

### DIFF
--- a/app/includes/alerts.tpl
+++ b/app/includes/alerts.tpl
@@ -1,0 +1,9 @@
+<div data-ng-repeat="alert in notifier.alerts">
+  <div class="alert popup alert-{{alert.type}} animated-show-hide"
+       style="bottom: {{55*$index}}px; z-index: {{999-$index}};">
+    <div class="container">
+      <div class='alert-message' ng-bind-html="alert.message"></div>
+    </div>
+    <i class="icon-close" ng-click="alert.close()"></i>
+  </div>
+</div>

--- a/app/layouts/cx-wallet.html
+++ b/app/layouts/cx-wallet.html
@@ -26,11 +26,7 @@
 
   </div>
 
-
-  <div class="alert popup {{notifier.class}} animated-show-hide" ng-show="notifier.show">
-    <div class="container" ng-bind-html="notifier.message"></div>
-    <i class="icon-close" ng-click="notifier.close()"></i>
-  </div>
+  @@include('../includes/alerts.tpl')
 
 </section>
 

--- a/app/layouts/embedded.html
+++ b/app/layouts/embedded.html
@@ -11,10 +11,9 @@
     </div>
 
     <!-- /tab panes -->
-  <article class="alert popup {{notifier.class}} animated-show-hide" ng-show="notifier.show">
-    <div class="container" ng-bind-html="notifier.message"></div>
-    <i class="icon-close" ng-click="notifier.close()"></i>
-  </article>
+
+  @@include('../includes/alerts.tpl')
+
 
   </section>
 

--- a/app/layouts/helpers.html
+++ b/app/layouts/helpers.html
@@ -10,11 +10,7 @@
 
   </div>
 
-
-  <div class="alert popup {{notifier.class}} animated-show-hide" ng-show="notifier.show" role="alert" aria-live="assertive">
-    <span class="sr-only">{{notifier.class}}</span><div class="container" ng-bind-html="notifier.message"></div>
-    <i tabindex="0" aria-label="dismiss" class="icon-close" ng-click="notifier.close()"></i>
-  </div>
+  @@include('../includes/alerts.tpl')
 
 </section>
 

--- a/app/layouts/index.html
+++ b/app/layouts/index.html
@@ -28,10 +28,8 @@
   </div>
 
 
-  <div class="alert popup {{notifier.class}} animated-show-hide" ng-show="notifier.show" role="alert" aria-live="assertive">
-    <span class="sr-only">{{notifier.class}}</span><div class="container" ng-bind-html="notifier.message"></div>
-    <i tabindex="0" aria-label="dismiss" class="icon-close" ng-click="notifier.close()"></i>
-  </div>
+  @@include('../includes/alerts.tpl')
+
 
   <!--
   <section class="loading-wrap" ng-hide="1==1">

--- a/app/layouts/signmsg.html
+++ b/app/layouts/signmsg.html
@@ -7,10 +7,9 @@
           <div ng-show="visibility=='signView' && wallet==null"><wallet-decrypt-drtv></wallet-decrypt-drtv></div>
         </div>
         <!-- /tab panes -->
-        <article class="alert popup {{notifier.class}} animated-show-hide" ng-show="notifier.show">
-            <div class="container" ng-bind-html="notifier.message"></div>
-            <i class="icon-close" ng-click="notifier.close()"></i>
-        </article>
+
+        @@include('../includes/alerts.tpl')
+
     </section>
 </section>
 @@include( '../includes/footerEmbedded.tpl', { "site": "mew" } )

--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -213,78 +213,46 @@ uiFuncs.transferAllBalance = function(fromAdd, gasLimit, callback) {
     }
 }
 uiFuncs.notifier = {
-    show: false,
-    messages: {},
-    close: function() {
-        this.show = false;
-        this.messages = {};
-        if (!this.scope.$$phase) this.scope.$apply()
-    },
-    open: function() {
-        this.show = true;
-        if (!this.scope.$$phase) this.scope.$apply();
-    },
-    class: '',
-    message: '',
-    timer: null,
-    sce: null,
-    scope: null,
-    overrideMsg: function(msg) {
-        console.log(msg)
-        return globalFuncs.getEthNodeMsg(msg);
-    },
+    alerts: {},
     warning: function(msg) {
-        this.addMessage("warning", msg);
+        this.addAlert("warning", msg);
     },
     info: function(msg) {
-        this.addMessage("info", msg);
+        this.addAlert("info", msg);
     },
     danger: function(msg) {
         msg = msg.message ? msg.message : msg;
-        msg = this.overrideMsg(msg);
-
-        this.addMessage("danger", msg, 0);
+        // Danger messages can be translated based on the type of node
+        msg = globalFuncs.getEthNodeMsg(msg);
+        this.addAlert("danger", msg, 0);
     },
     success: function(msg) {
-        this.addMessage("success", msg);
+        this.addAlert("success", msg);
     },
-    addMessage: function(type, msg, duration) {
+    addAlert: function(type, msg, duration) {
         if (duration == undefined)
             duration = 5000;
         // Save all messages by unique id for removal
         var id = Date.now();
-        this.messages[id] = {type: type, msg: msg};
+        alert = this.buildAlert(id, type, msg);
+        this.alerts[id] = alert
         var that = this;
         if (duration > 0) { // Support permanent messages
-            setTimeout(function() {
-                // Remove the message and rebuild the UI
-                delete that.messages[id];
-                that.rebuildMessages();
-            }, duration);
+            setTimeout(alert.close, duration);
         }
-        this.rebuildMessages();
+        if (!this.scope.$$phase) this.scope.$apply();
     },
-    rebuildMessages: function() {
-        if (Object.values(this.messages).length > 0) {
-            var types = Object.values(this.messages).map(function(message) { return message.type });
-            this.message = Object.values(this.messages).map(function(message) { return message.msg })
-                                                       .join("<br />");
-            this.setMostImportantClass(types);
-            this.open();
-        } else {
-            this.close();
+    buildAlert: function(id, type, msg) {
+        var that = this;
+        return {
+            show: true,
+            type: type,
+            message: msg,
+            close: function() {
+                delete that.alerts[id];
+                if (!that.scope.$$phase) that.scope.$apply();
+            }
         }
     },
-    setMostImportantClass: function(types) {
-        if (types.indexOf('danger') > -1) {
-            this.class = 'alert-danger';
-        } else if (types.indexOf('warning') > -1) {
-            this.class = 'alert-warning';
-        } else if (types.indexOf('success') > -1) {
-            this.class = 'alert-success';
-        } else {
-            this.class = '';
-        }
-    }
-}
+  }
 module.exports = uiFuncs;

--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -266,25 +266,25 @@ uiFuncs.notifier = {
     },
     rebuildMessages: function() {
         if (Object.values(this.messages).length > 0) {
-          var types = Object.values(this.messages).map(function(message) { return message.type });
-          this.message = Object.values(this.messages).map(function(message) { return message.msg })
-                                                     .join("<br />");
-          this.setMostImportantClass(types);
-          this.open();
+            var types = Object.values(this.messages).map(function(message) { return message.type });
+            this.message = Object.values(this.messages).map(function(message) { return message.msg })
+                                                       .join("<br />");
+            this.setMostImportantClass(types);
+            this.open();
         } else {
-          this.close();
+            this.close();
         }
     },
     setMostImportantClass: function(types) {
-      if (types.indexOf('danger') > -1) {
-        this.class = 'alert-danger';
-      } else if (types.indexOf('warning') > -1) {
-        this.class = 'alert-warning';
-      } else if (types.indexOf('success') > -1) {
-        this.class = 'alert-success';
-      } else {
-        this.class = '';
-      }
+        if (types.indexOf('danger') > -1) {
+            this.class = 'alert-danger';
+        } else if (types.indexOf('warning') > -1) {
+            this.class = 'alert-warning';
+        } else if (types.indexOf('success') > -1) {
+            this.class = 'alert-success';
+        } else {
+            this.class = '';
+        }
     }
 }
 module.exports = uiFuncs;


### PR DESCRIPTION
Store all messages with their own timeouts, build the message each time one is added or expires. Show each event in its own container and stack them up. Danger messages must be closed manually as before.

![alerts](https://user-images.githubusercontent.com/45890/27440021-06b77360-579c-11e7-97fb-ff6f2236341f.gif)

Addresses #473 

I'm not sure how to test the ENS to prove this actually fixes the bug. But this should be a much more robust notification system.

Known issues (To be dealt with in separate style pass):

- At mobile widths the stacking (fixed at 55px) means the alerts overlap each other as they expand vertically.
- When the alerts have enough text to wrap you also get the vertical overlap