### PR TITLE
Default to TLS 443 port for Infura nodes

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -59,7 +59,7 @@ nodes.nodeList = {
         'tokenList': require('./tokens/ethTokens.json'),
         'abiList': require('./abiDefinitions/ethAbi.json'),
         'service': 'infura.io',
-        'lib': new nodes.infuraNode('https://mainnet.infura.io/mew', '8545')
+        'lib': new nodes.infuraNode('https://mainnet.infura.io/mew')
     },
     'etc_epool': {
         'name': 'ETC',


### PR DESCRIPTION
@kvhnuke 
We were testing the INFURA provider and noticed that the port was being appended incorrectly like this:
```
https://mainnet.infura.io/mew:8545
```
We actually support both 8545 and 443 for backwards compatibility (both over TLS). I removed the 8545 port to fix the `SERVERURL` concatenation. We actually prefer if users default to using port 443.