### PR TITLE
Rename zips and add parent directory

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -256,7 +256,10 @@ gulp.task('getVersion', function() {
 gulp.task('zip', ['getVersion'], function() {
     gulp.src(dist + '**/**/*')
         .pipe(plumber({ errorHandler: onError }))
-        .pipe(zip('./dist-' + versionNum + '.zip'))
+        .pipe(rename(function (path) {
+          path.dirname = './etherwallet-' + versionNum + '/' + path.dirname;
+        }))
+        .pipe(zip('./etherwallet-' + versionNum + '.zip'))
         .pipe(gulp.dest('./releases/'))
         .pipe(notify(onSuccess('Zip Dist ' + versionNum)));
     return gulp.src(dist_CX + '**/**/*')
@@ -304,7 +307,10 @@ function archive() {
 gulp.task('travisZip', ['getVersion'], function() {
     gulp.src(dist + '**/**/*')
         .pipe(plumber({ errorHandler: onError }))
-        .pipe(zip('./dist-' + versionNum + '.zip'))
+        .pipe(rename(function (path) {
+          path.dirname = './etherwallet-' + versionNum + '/' + path.dirname;
+        }))
+        .pipe(zip('./etherwallet-' + versionNum + '.zip'))
         .pipe(gulp.dest('./deploy/'))
         .pipe(notify(onSuccess('Zip Dist ' + versionNum)));
     return gulp.src(dist_CX + '**/**/*')


### PR DESCRIPTION
This commit changes the zip and travisZip tasks to create a single
parent directory in the created zip files. Previously, unzipping would
dump the files in the current directory. Zip files are also renamed
from dist-vXXX to etherwallet-vXXX.

Closes #404 