### PR TITLE
Fix typo in SHIT token symbol

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -289,7 +289,7 @@
   },
   {
     "address":"0xef2e9966eb61bb494e5375d5df8d67b7db8a780d",
-    "symbol":"SHT",
+    "symbol":"SHIT",
     "decimal":0,
     "type":"default"
   },


### PR DESCRIPTION
Hello I am Shitoshi Crapamoto the creator of https://www.shitcoin.io/ A typo has appeared in our great and honorable symbol! Here is a PR to fix this travesty. Please get on the rocket ship and see you on Uranus!

Warm Regards,
Dr. Shitoshi Crapamoto
shitoshi@shitcoin.io