### PR TITLE
Added AdToken to Defaults

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -6,6 +6,12 @@
     "type":"default"
   },
   {
+    "address":"0xD0D6D6C5Fe4a677D343cC433536BB717bAe167dD",
+    "symbol":"ADT",
+    "decimal":9,
+    "type":"default"
+  },
+  {
     "address":"0x960b236A07cf122663c4303350609A66A7B288C0",
     "symbol":"ANT",
     "decimal":18,


### PR DESCRIPTION
AdToken is a simple, closed-loop incentive game which organizes its players to produce a high-quality publisher whitelist useful for programmatic header-bidding. AdToken was developed by MetaX with support from ConsenSys.

https://adtoken.com
https://adchain.slack.com
https://www.reddit.com/r/adChain/
https://twitter.com/ad_chain
https://github.com/adchain
https://metax.io/

Support email: hello@metax.io