### PR TITLE
Make scripts for the two gulp actions. Update readme to point to them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ If you want to help contribute, here's what you need to know to get it up and ru
 **Getting Started**
 
 - Start by running `npm install`.
-- Run `gulp`. Gulp will then watch & compile everything and then watch for changes to the HTML, JS, or CSS.
-- For distribution, run `gulp clean`.
+- Run `npm run dev`. Gulp will then watch & compile everything and then watch for changes to the HTML, JS, or CSS.
+- For distribution, run `npm run dist`.
 
 **Folder Structure**
 - `fonts` and `images` get moved into their respective folders. This isn't watched via gulp so if you add an image or font, you need to run `gulp` again.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "gulpfile.js",
   "author": "MyEtherWallet",
   "license": "ISC",
+  "scripts": {
+    "dev": "gulp",
+    "dist": "gulp clean"
+  },
   "devDependencies": {
     "angular": "^1.6.2",
     "angular-animate": "^1.6.2",


### PR DESCRIPTION
The current instructions to `npm install` then run `gulp` aren't quite right. That only works if you have `gulp-cli` installed globally already. Otherwise, you get `-bash: gulp: command not found`. You would have to run `node_modules/.bin/gulp` if you wanted to run it directly from the command line, as your $PATH isn't node_modules aware.

However, package.json scripts _are_ node_modules aware. All this PR does is add a `dev` and a `dist` script that runs `gulp` and `gulp clean` respectively. I also updated the readme to suggest running those two instead.