### PR TITLE
Generate and use uglified JS with gulp `prep` task

### DIFF
--- a/app/includes/header.tpl
+++ b/app/includes/header.tpl
@@ -9,7 +9,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="css/etherwallet-master.min.css">
   <script type="text/javascript" src="js/etherwallet-static.min.js"></script>
-  <script type="text/javascript" src="js/etherwallet-master.js"></script>
+
+  @@if (production) {
+    <script type="text/javascript" src="js/etherwallet-master.min.js"></script>
+  }
+
+  @@if (!production) {
+    <script type="text/javascript" src="js/etherwallet-master.js"></script>
+  }
 
   <link rel="apple-touch-icon" sizes="180x180" href="images/fav/apple-touch-icon.png">
   <link rel="icon" type="image/png" href="images/fav/favicon-32x32.png" sizes="32x32">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,15 +156,15 @@ function bundle_js(options) {
 
 
 gulp.task('js', function() {
-    bundle_js();
+    return bundle_js();
 });
 
 gulp.task('js-production', function() {
-    bundle_js({ production: true });
+    return bundle_js({ production: true });
 });
 
 gulp.task('js-debug', function() {
-    bundle_js({ debug: true });
+    return bundle_js({ debug: true });
 });
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,6 +21,7 @@ const source       = require('vinyl-source-stream');
 const uglify       = require('gulp-uglify');
 const zip          = require('gulp-zip');
 const html2js      = require('html2js-browserify');
+const gulpif       = require('gulp-if');
 
 const app          = './app/';
 const dist         = './dist/';
@@ -60,13 +61,31 @@ function notifyFunc(msg) {
 let htmlFiles = app + 'layouts/*.html';
 let tplFiles = app + 'includes/*.tpl';
 
-gulp.task('html', function(done) {
-    return gulp.src(htmlFiles)
-        .pipe(plumber({ errorHandler: onError }))
-        .pipe(fileinclude({ prefix: '@@', basepath: '@file' }))
-        .pipe(gulp.dest(dist))
-        .pipe(gulp.dest(dist_CX))
-        .pipe(notify(onSuccess('HTML')))
+function bundle_html(options) {
+  options = Object.assign({
+    production: false,
+  }, options);
+
+  return gulp.src(htmlFiles)
+      .pipe(plumber({ errorHandler: onError }))
+      .pipe(fileinclude({
+        prefix: '@@',
+        basepath: '@file',
+        context: {
+          production: options.production,
+        },
+      }))
+      .pipe(gulp.dest(dist))
+      .pipe(gulp.dest(dist_CX))
+      .pipe(notify(onSuccess('HTML')));
+}
+
+gulp.task('html', function() {
+    bundle_html();
+});
+
+gulp.task('html-production', function() {
+    bundle_html({ production: true });
 });
 
 
@@ -101,49 +120,51 @@ let js_srcFile = app + 'scripts/main.js';
 let js_destFolder = dist + 'js/';
 let js_destFolder_CX = dist_CX + 'js/';
 let js_destFile = 'etherwallet-master.js';
-let browseOpts = { debug: true }; // generates inline source maps - only in js-debug
-let babelOpts = {
+let js_destFileMin = 'etherwallet-master.min.js';
+
+function bundle_js(options) {
+  options = Object.assign({
+    destFile: js_destFile,
+    debug: false,
+    production: false,
+  }, options || {});
+
+  const browserifyOpts = {
+    debug: options.debug,
+  };
+
+  const babelOpts = {
     presets: ['es2015'],
-    compact: false,
-    global: true
-};
+    global: true,
+    compact: options.production,
+  };
 
-function bundle_js(bundler) {
-    return bundler.bundle()
-        .pipe(plumber({ errorHandler: onError }))
-        .pipe(source('main.js'))
-        .pipe(buffer())
-        .pipe(rename(js_destFile))
-        .pipe(gulp.dest(js_destFolder))
-        .pipe(gulp.dest(js_destFolder_CX))
-        .pipe(notify(onSuccess('JS')))
-}
+  const bundler = browserify(js_srcFile, browserifyOpts)
+    .transform(babelify, babelOpts)
+    .transform(html2js);
 
-function bundle_js_debug(bundler) {
-    return bundler.bundle()
-        .pipe(plumber({ errorHandler: onError }))
-        .pipe(source('main.js'))
-        .pipe(buffer())
-        .pipe(rename(js_destFile))
-        .pipe(gulp.dest(js_destFolder))
-        .pipe(gulp.dest(js_destFolder_CX))
-        .pipe(notify(onSuccess('JS')))
+  return bundler.bundle()
+    .pipe(plumber({ errorHandler: onError }))
+    .pipe(source('main.js'))
+    .pipe(buffer())
+    .pipe(gulpif(options.production, uglify()))
+    .pipe(rename(options.production ? js_destFileMin : js_destFile))
+    .pipe(gulp.dest(js_destFolder))
+    .pipe(gulp.dest(js_destFolder_CX))
+    .pipe(notify(onSuccess('JS')));
 }
 
 
 gulp.task('js', function() {
-    let bundler = browserify(js_srcFile).transform(babelify).transform(html2js);
-    bundle_js(bundler)
+    bundle_js();
 });
 
 gulp.task('js-production', function() {
-    let bundler = browserify(js_srcFile).transform(babelify, babelOpts).transform(html2js);
-    bundle_js(bundler)
+    bundle_js({ production: true });
 });
 
 gulp.task('js-debug', function() {
-    let bundler = browserify(js_srcFile, browseOpts).transform(babelify, babelOpts).transform(html2js);
-    bundle_js_debug(bundler)
+    bundle_js({ debug: true });
 });
 
 
@@ -377,13 +398,15 @@ gulp.task('pushlive', ['getVersion'], function() {
 // git push --tags
 // gulp pushlive ( git subtree push --prefix dist origin gh-pages )
 
-gulp.task('watchJS',      function() { gulp.watch(js_watchFolder,   ['js']            ) })
-gulp.task('watchJSDebug', function() { gulp.watch(js_watchFolder,   ['js-debug']      ) })
-gulp.task('watchJSProd',  function() { gulp.watch(js_watchFolder,   ['js-production'] ) })
-gulp.task('watchLess',    function() { gulp.watch(less_watchFolder, ['styles']        ) })
-gulp.task('watchPAGES',   function() { gulp.watch(htmlFiles,        ['html']          ) })
-gulp.task('watchTPL',     function() { gulp.watch(tplFiles,         ['html']          ) })
-gulp.task('watchCX',      function() { gulp.watch(cxSrcFiles,       ['copy']          ) })
+gulp.task('watchJS',        function() { gulp.watch(js_watchFolder,   ['js']              ) })
+gulp.task('watchJSDebug',   function() { gulp.watch(js_watchFolder,   ['js-debug']        ) })
+gulp.task('watchJSProd',    function() { gulp.watch(js_watchFolder,   ['js-production']   ) })
+gulp.task('watchLess',      function() { gulp.watch(less_watchFolder, ['styles']          ) })
+gulp.task('watchPAGES',     function() { gulp.watch(htmlFiles,        ['html']            ) })
+gulp.task('watchPAGESProd', function() { gulp.watch(htmlFiles,        ['html-production'] ) })
+gulp.task('watchTPL',       function() { gulp.watch(tplFiles,         ['html']            ) })
+gulp.task('watchTPLProd',   function() { gulp.watch(tplFiles,         ['html-production'] ) })
+gulp.task('watchCX',        function() { gulp.watch(cxSrcFiles,       ['copy']            ) })
 
 gulp.task('bump',          function() { return bumpFunc( 'patch' ) });
 gulp.task('bump-patch',    function() { return bumpFunc( 'patch' ) });
@@ -391,7 +414,7 @@ gulp.task('bump-minor',    function() { return bumpFunc( 'minor' ) });
 
 gulp.task('archive',       function() { return archive() });
 
-gulp.task('prep',   function(cb) { runSequence('js-production', 'html', 'styles', 'copy', cb); });
+gulp.task('prep',   function(cb) { runSequence('js-production', 'html-production', 'styles', 'copy', cb); });
 
 gulp.task('bump',   function(cb) { runSequence('bump-patch', 'clean', 'zip', cb);              });
 
@@ -399,8 +422,8 @@ gulp.task('zipit',  function(cb) { runSequence('clean', 'zip', cb);             
 
 gulp.task('commit', function(cb) { runSequence('add', 'commitV', 'tag', cb);                   });
 
-gulp.task('watch',     ['watchJS',     'watchLess', 'watchPAGES', 'watchTPL', 'watchCX'])
-gulp.task('watchProd', ['watchJSProd', 'watchLess', 'watchPAGES', 'watchTPL', 'watchCX'])
+gulp.task('watch',     ['watchJS',     'watchLess', 'watchPAGES',     'watchTPL',     'watchCX'])
+gulp.task('watchProd', ['watchJSProd', 'watchLess', 'watchPAGESProd', 'watchTPLProd', 'watchCX'])
 
 gulp.task('build', ['js', 'html', 'styles', 'copy']);
 gulp.task('build-debug', ['js-debug', 'html', 'styles', 'watchJSDebug', 'watchLess', 'watchPAGES', 'watchTPL', 'watchCX'])

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "gulp-concat": "^2.6.1",
     "gulp-cssnano": "^2.1.2",
     "gulp-file-include": "^1.1.0",
+    "gulp-if": "^2.0.2",
     "gulp-less": "^3.3.0",
     "gulp-notify": "^3.0.0",
     "gulp-plumber": "^1.1.0",


### PR DESCRIPTION
## What I Did

I decided to take my own crack at #729 and generate a minified version of etherwallet-master.js. This pull request primarily does a few things:

* Causes the `js-production` task to generate a file at `etherwallet-master.min.js` that has been run through `uglify`
* Adds `html-production`, `watchPAGESProd`, and `watchTPLProd` tasks that provide the `production: true` context to templates
* Changed `header.tpl` to load the minified js instead of the regular when production is true

Secondarily, I also did a little cleanup of the js part of gulp to put it all under the `bundle_js` function that just takes in arguments. I also added the `gulp-if` module to keep some of the logic smaller, since that seems to be the preferred way of doing conditional pipes.

## The Effects

`etherwallet-master.js` got cut down from 4.9mb to 2.6mb (46.9% savings). In addition to the improved network performance, this also gives us a nice little page load boost for your browser parsing the JS file itself, as seen by the `Evaluate Script (etherwallet-master.js:1)` portion of the performance timeline in Chrome. This went down from 364.18ms to 296.64ms on average, on my machine.

_Testing was done on an early 2015 macbook pro running Chrome 59, doing 6 reloads and dropping the lowest for each._

## Caveats

Right now index.html behaves differently depending on whether or not you run `html-production` or `html`. This could be seen as kind of confusing, and I don't know if it has any negative effects on the deploy process, or the fact that `dist/` is currently in version control.

I also didn't do extensive testing of MEW to make sure this didn't break anything, but I trust that uglify does the right thing. However, I thought that someone more familiar with the testing process could give it a shot.

Let me know if I messed up anything preferred JS style or gulp wise, I'm more accustomed to webpack.