### PR TITLE
change FUN address

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -162,7 +162,7 @@
     "type":"default"
   },
   {
-    "address":"0xBbB1BD2D741F05E144E6C4517676a15554fD4B8D",
+    "address":"0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
     "symbol":"FUN",
     "decimal":8,
     "type":"default"


### PR DESCRIPTION
The FUN token is moving to a new address at 10AM PST. I will post an update here once the new address starts accepting transfers.