### PR TITLE
Change FUN token address.

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -162,7 +162,7 @@
     "type":"default"
   },
   {
-    "address":"0xBbB1BD2D741F05E144E6C4517676a15554fD4B8D",
+    "address":"0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
     "symbol":"FUN",
     "decimal":8,
     "type":"default"


### PR DESCRIPTION
FunFair changed their token contract. Migrated over all balances. I double checked in their Discord, it is valid.  And the new contract has the same balance for my address as the old one.

See Notification: http://mailchi.mp/e4a30444fbcb/new-fun-token-contract