### PR TITLE
Add the Macroverse Token (MRV)

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -300,6 +300,12 @@
     "type":"default"
   },
   {
+    "address":"0xAB6CF87a50F17d7F5E1FEaf81B6fE9FfBe8EBF84",
+    "symbol":"MRV",
+    "decimal":18,
+    "type":"default"
+  },
+  {
     "address":"0x68AA3F232dA9bdC2343465545794ef3eEa5209BD",
     "symbol":"MSP",
     "decimal":18,


### PR DESCRIPTION
This is the token used in Novak Distributed's [Macroverse](https://macroverse.io/) project, and is registered in the [Parity token registry](https://etherscan.io/address/0x5f0281910af44bfb5fc7e86a404d0304b0e042f1#readContract) as MRV with ID 310.