### PR TITLE
feature: show brand color on button

### DIFF
--- a/app/includes/generateWallet.tpl
+++ b/app/includes/generateWallet.tpl
@@ -16,7 +16,7 @@
              aria-label="{{'GEN_Label_1' |translate}}"/>
         <span tabindex="0" aria-label="make password visible" role="button" class="input-group-addon eye" ng-click="showPass=!showPass"></span>
       </div>
-      <a tabindex="0" role="button" class="btn btn-primary" func="generateSingleWallet" ng-click="genNewWallet()" translate="NAV_GenerateWallet">Generate Wallet</a>
+      <a tabindex="0" ng-class="btn-{{curNode.name}}" role="button" class="btn btn-primary btn-{{globalService.curNode.name}}" func="generateSingleWallet" ng-click="genNewWallet()" translate="NAV_GenerateWallet">Generate Wallet</a>
       <p translate="x_PasswordDesc"> </p>
       <br>
     </section>

--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -55,6 +55,7 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
         } else {
             $scope.curNode = $scope.nodeList[$scope.defaultNodeKey];
         }
+        $scope.gService.curNode = $scope.curNode;
         $scope.dropdownNode = false;
         Token.popTokens = $scope.curNode.tokenList;
         ajaxReq['key'] = key;

--- a/app/styles/etherwallet-custom.less
+++ b/app/styles/etherwallet-custom.less
@@ -471,7 +471,7 @@ label small {
 
 // color code the nodes
 @brand-eth: @brand-primary;
-@brand-etc: #9c27b0;
+@brand-etc: #669073;
 @brand-test: #cddc39;
 @brand-cust: #9c27b0;
 @brand-rsk: #ff794f;
@@ -583,5 +583,37 @@ header.Custom + .container + .pre-footer + .footer {
   }
 }
 
+.btn-ETH {
+    background-color: @brand-eth;
+    border-color: @brand-eth;
+}
 
+.btn-ETC {
+    background-color: @brand-etc;
+    border-color: @brand-etc;
+}
 
+.btn-Ropsten {
+    background-color: @brand-test;
+    border-color: @brand-test;
+}
+
+.btn-Kovan {
+    background-color: @brand-test;
+    border-color: @brand-test;
+}
+
+.btn-Rinkeby {
+    background-color: @brand-test;
+    border-color: @brand-test;
+}
+
+.btn-RSK {
+    background-color: @brand-rsk;
+    border-color: @brand-rsk;
+}
+
+.btn-Custom {
+    background-color: @brand-cust;
+    border-color: @brand-cust;
+}


### PR DESCRIPTION
Users find it difficult to distinguish which chain they are in when they use the MEW. The only difference is now a single character in top right corner. Here we show brand color on button on diffrent chain :) The etc color is rewrite to `#669073` from [ethereumclassic.github.io/](https://ethereumclassic.github.io/)

Now the different color  is the following:

<img width="1279" alt="screen shot 2017-07-30 at 19 04 45" src="https://user-images.githubusercontent.com/3370345/28752776-12e31276-755a-11e7-9839-fccebe4a882f.png">
<img width="1280" alt="screen shot 2017-07-30 at 19 04 53" src="https://user-images.githubusercontent.com/3370345/28752777-16b4c714-755a-11e7-9510-759995ed98c5.png">
<img width="1279" alt="screen shot 2017-07-30 at 19 05 02" src="https://user-images.githubusercontent.com/3370345/28752779-18e6faca-755a-11e7-972c-8f0ffced0be9.png">
<img width="1280" alt="screen shot 2017-07-30 at 19 05 08" src="https://user-images.githubusercontent.com/3370345/28752780-1adcb3ba-755a-11e7-9522-f0bd897fc46d.png">
