### PR TITLE
Added 300, ATH, PRS Token for Battle Contract

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -6,6 +6,12 @@
     "type":"default"
   },
   {
+    "address":"0xaEc98A708810414878c3BCDF46Aad31dEd4a4557",
+    "symbol":"300",
+    "decimal":18,
+    "type":"default"
+  },
+  {
     "address":"0x422866a8F0b032c5cf1DfBDEf31A20F4509562b0",
     "symbol":"ADST",
     "decimal":0,
@@ -38,6 +44,12 @@
   {
     "address":"0xAc709FcB44a43c35F0DA4e3163b117A17F3770f5",
     "symbol":"ARC",
+    "decimal":18,
+    "type":"default"
+  },
+  {
+    "address":"0x17052d51E954592C1046320c2371AbaB6C73Ef10",
+    "symbol":"ATH",
     "decimal":18,
     "type":"default"
   },
@@ -452,6 +464,12 @@
   {
     "address":"0xe3818504c1B32bF1557b16C238B2E01Fd3149C17",
     "symbol":"PLR",
+    "decimal":18,
+    "type":"default"
+  },
+  {
+    "address":"0x163733bcc28dbf26B41a8CfA83e369b5B3af741b",
+    "symbol":"PRS",
     "decimal":18,
     "type":"default"
   },


### PR DESCRIPTION
On 19th August we will release a Smart Contract for a virtual battle. The contract will use 300, ATH, PRS token plus the IMT token added previusly to myetherwallet.
To help users with battle contract we would like to add the other tokens to MEW.

Website & Public channel for Persian & Immortal token:
- Twitter: https://twitter.com/persian_token
- WebSite: http://persians.network/
- GitHub: https://github.com/Neurone/persians
- Slack: https://battlesmartcontract.slack.com/
- Mail: king.serse@gmx.com

Website & public channel for 300 Token:
- Twitter: https://twitter.com/300_Token
- WebSite: https://300tokensparta.com

Website & public channel for ATH Token:
- Twitter: https://twitter.com/ATHwarriortoken
- WebSite: https://athenianwarriortoken.com


