### PR TITLE
HotFix - avoid metamask network

### DIFF
--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -82,7 +82,10 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
     }
     $scope.setCurNodeFromStorage = function() {
         var node = globalFuncs.localStorage.getItem('curNode', null);
-        if (node == null) {
+        if (node === JSON.stringify({"key":"eth_metamask"})) {
+          node = JSON.stringify({"key":"eth_infura"})
+        }
+       if (node == null) {
             $scope.changeNode($scope.defaultNodeKey);
         } else {
             node = JSON.parse(node);

--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -41,18 +41,6 @@ nodes.nodeList = {
         'service': 'MyEtherWallet',
         'lib': new nodes.customNode('https://api.myetherapi.com/eth', '')
     },
-    'eth_metamask': {
-        'name': 'ETH',
-        'blockExplorerTX': 'https://etherscan.io/tx/[[txHash]]',
-        'blockExplorerAddr': 'https://etherscan.io/address/[[address]]',
-        'type': nodes.nodeTypes.ETH,
-        'eip155': true,
-        'chainId': 1,
-        'tokenList': require('./tokens/ethTokens.json'),
-        'abiList': require('./abiDefinitions/ethAbi.json'),
-        'service': 'MetaMask/Mist',
-        'lib': new nodes.metamaskNode()
-    },
     'eth_ethscan': {
         'name': 'ETH',
         'blockExplorerTX': 'https://etherscan.io/tx/[[txHash]]',


### PR DESCRIPTION
#### Why?
When selecting metamask as the network, and refreshing, the following error appears.
<img width="1238" alt="screen shot 2017-08-11 at 1 15 46 am" src="https://user-images.githubusercontent.com/7861465/29197351-a140d66c-7e32-11e7-8dc1-aa11fd6e10a8.png">

#### Solution
As a temporary stop gap, metamask is removed as a node option, and when already stored in localstorage, is replaced with infura. 
