### PR TITLE
pt.js - Added missing strings

### DIFF
--- a/app/scripts/translations/pt.js
+++ b/app/scripts/translations/pt.js
@@ -100,6 +100,7 @@ x_JsonDesc                  : 'Este é o descriptografado, formato JSON da sua c
 x_Keystore                  : 'Arquivo de armazenamento de chaves (UTC / JSON · Recomendado · Criptografado) ',
 x_Keystore2                 : 'Arquivo de armazenamento de chaves (UTC / JSON) ',
 x_KeystoreDesc              : 'Este arquivo de armazenamento de chaves corresponde ao formato usado pela Mist para que você possa facilmente importá-lo no futuro. É recomendado que o arquivo seja transferido e feito seu backup. ',
+x_MetaMask                  : 'Metamask / Mist ',
 x_Mnemonic                  : 'Frase Mnemonic ',
 x_ParityPhrase              : 'Parity Phrase ',
 x_Password                  : 'Senha ',
@@ -154,6 +155,11 @@ ADD_Radio_3                 : 'Cole/Digite sua Chave Privada ',
 ADD_Radio_4                 : 'Adicionar uma conta para ver ',
 ADD_Radio_5                 : 'Cole/Digite sua Mnemonic ',
 ADD_Radio_5_Path            : 'Select HD derivation path ',
+ADD_Radio_5_woTrezor        : '(Jaxx, Metamask, Exodus, imToken)',
+ADD_Radio_5_withTrezor      : '(Jaxx, Metamask, Exodus, imToken, TREZOR)',
+ADD_Radio_5_PathAlternative : '(Ledger)',
+ADD_Radio_5_PathTrezor      : '(TREZOR)',
+ADD_Radio_5_PathCustom      : 'Custom',
 ADD_Label_2                 : 'Crie um Apelido: ',
 ADD_Label_3                 : 'Sua carteira é criptografada. Por favor, insira a senha ',
 ADD_Label_4                 : 'Adicionar uma conta para ver ',
@@ -162,6 +168,7 @@ ADD_Label_5                 : 'Insira o Endereço ',
 ADD_Label_6                 : 'Desbloqueie sua Carteira ',
 ADD_Label_6_short           : 'Desbloqueie ',
 ADD_Label_7                 : 'Adicionar Conta ',
+ADD_Label_8                 : 'Password (optional): ',
 
 /* Generate Wallets */
 GEN_desc                    : 'Se você quer gerar multiplas carteiras. você pode fazer isso aqui ',
@@ -266,6 +273,8 @@ MYWAL_Content_3             : 'Se pretender utilizar esta carteira com o MyEther
 VIEWWALLET_Subtitle         : 'This allows you to download different versions of private keys and re-print your paper wallet. You may want to do this in order to [import your account into Geth/Mist](http://ethereum.stackexchange.com/questions/465/how-to-import-a-plain-private-key-into-geth/). If you want to check your balance, we recommend using a blockchain explorer like [etherscan.io](http://etherscan.io/). ',
 VIEWWALLET_Subtitle_Short   : 'This allows you to download different versions of private keys and re-print your paper wallet. ',
 VIEWWALLET_SuccessMsg       : 'Success! Here are your wallet details. ',
+VIEWWALLET_ShowPrivKey      : '(show)',
+VIEWWALLET_HidePrivKey      : '(hide)',
 
 /* Mnemonic */
 MNEM_1                      : 'Por favor, selecione o endereço com o qual você gostaria de interagir. ',
@@ -290,6 +299,7 @@ x_DigitalBitbox             : 'Digital Bitbox ',
 ADD_DigitalBitbox_0a        : 'Re-abra MyEtherWallet em uma conexão (SSL) segura ',
 ADD_DigitalBitbox_0b        : 'Re-abra MyEtherWallet usando [Chrome](https://www.google.com/chrome/browser/desktop/) ou [Opera](https://www.opera.com/) ',
 ADD_DigitalBitbox_scan      : 'Conectar-se a Digital Bitbox ',
+ADD_MetaMask                : 'Connect to MetaMask ',
 
 /* Node Switcher */
 NODE_Title                  : 'Set Up Your Custom Node',
@@ -326,6 +336,7 @@ SWAP_rec_add                : "Your Receiving Address ",
 SWAP_start_CTA              : "Start Swap ",
 SWAP_ref_num                : "Your reference number ",
 SWAP_time                   : "Time remaining to send ",
+SWAP_elapsed				        : "Time elapsed since sent ",
 SWAP_progress_1             : "Order Initiated ",
 SWAP_progress_2             : "Waiting for your ", // Waiting for your BTC...
 SWAP_progress_3             : "Received! ", // ETH Received!
@@ -384,6 +395,8 @@ ERROR_32                    : 'Could not connect to the node. Refresh your page,
 ERROR_33                    : 'The wallet you have unlocked does not match the owner\'s address. ', // 33
 ERROR_34                    : 'The name you are attempting to reveal does not match the name you have entered. ', // 34
 ERROR_35                    : 'Input address is not checksummed. <a href="https://myetherwallet.groovehq.com/knowledge_base/topics/not-checksummed-shows-when-i-enter-an-address" target="_blank" rel="noopener"> More info</a>', // 35
+ERROR_36                    : 'Enter valid TX hash', // 36
+ERROR_37                    : 'Enter valid hex string (0-9, a-f)', // 37
 
 SUCCESS_1                   : 'Valid address ',
 SUCCESS_2                   : 'Wallet successfully decrypted ',


### PR DESCRIPTION
It seems I forgot to update Portuguese. The script (now at https://github.com/jzu/new_mew_strings) also brought up leftovers in ar and zhtw.

ADD_Label_8
ADD_MetaMask
ADD_Radio_5_PathAlternative
ADD_Radio_5_PathCustom
ADD_Radio_5_PathTrezor
ADD_Radio_5_withTrezor
ADD_Radio_5_woTrezor
ERROR_36
ERROR_37
SWAP_elapsed
VIEWWALLET_HidePrivKey
VIEWWALLET_ShowPrivKey
x_MetaMask