### PR TITLE
Security update for Trezor

### DIFF
--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -269,7 +269,7 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
     $scope.scanTrezor = function() {
         // trezor is using the path without change level id
         var path = $scope.getTrezorPath();
-        TrezorConnect.getXPubKey(path, $scope.trezorCallback, '1.4.0');
+        TrezorConnect.getXPubKey(path, $scope.trezorCallback, '1.5.2');
     };
     $scope.getLedgerPath = function() {
         return $scope.HDWallet.dPath;


### PR DESCRIPTION
Firmware 1.4.0 to 1.5.2 
see also: https://github.com/trezor/connect/issues/73
and here: https://blog.trezor.io/trezor-firmware-security-update-1-5-2-5ef1b6f13fed

now you can sign a message with an trezor! You can test it here: https://mytokenwallet.com/signmsg.html 
You need FW: 1.5.2 past fw versions will not work for signing a ether message 