### PR TITLE
Bigger QR-Code to scan from smartphone

### DIFF
--- a/app/includes/offlineTx-3.tpl
+++ b/app/includes/offlineTx-3.tpl
@@ -8,5 +8,5 @@
   <textarea class="form-control" rows="3" ng-model="signedTx"></textarea>
 
   <a class="btn btn-primary" ng-click="confirmSendTx()" translate="SEND_trans">SEND TRANSACTION</a>
-
+<div class="qr-code" qr-code="{{signedTx}}" watch-var="signedTx" width="100%"></div>
 </article>


### PR DESCRIPTION
Hi @channel,
I have developed a small tool to push/broadcast signed Ethereum transactions.
Test it here: https://mytokenwallet.com/qr-scan-app.html

Problem: the existing qr-code is too small, and with this pull request everyone can perfect scan the code.

Features on my QR-Code scanner:
* scan qr-code to:
    * send/push transactions
        * feedback from etherscan
    * open ether address on etherscan
    * open scanned url’s
    * read qr-code from file