### PR TITLE
remove superfluous error messages for Digital Bitbox; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@
 #### Features
 
 - Create new wallets completely client side.
-- Access your wallet via unencrypted private key, encrypted private key, keystore files, mnemonics, Ledger Nano S & TREZOR hardware wallet.
+- Access your wallet via unencrypted private key, encrypted private key, keystore files, mnemonics, or Digital Bitbox, Ledger Nano S or TREZOR hardware wallet.
 - Easily send ETH and *any* ERC-20 Standard Token. [Many tokens included as default.](https://myetherwallet.groovehq.com/knowledge_base/topics/can-i-send-my-steem-slash-btc-slash-ltc-slash-nem-slash-to-myetherwallet)
 - Generate, sign & send transactions offline, ensuring your private keys never touch an internet-connected device.
-- Securely access your ETH & Tokens on your [Ledger or TREZOR Hardware Wallet](https://myetherwallet.groovehq.com/knowledge_base/topics/hardware-wallet-recommends) via the MyEtherWallet interface (Chrome & Opera natively, Firefox w/ [add-on](https://addons.mozilla.org/en-US/firefox/addon/u2f-support-add-on/))
+- Securely access your ETH & Tokens on your [Digital Bitbox, Ledger or TREZOR Hardware Wallet](https://myetherwallet.groovehq.com/knowledge_base/topics/hardware-wallet-recommends) via the MyEtherWallet interface (Chrome & Opera natively, Firefox w/ [add-on](https://addons.mozilla.org/en-US/firefox/addon/u2f-support-add-on/))
 - Now in 18 languages thanks 100% to the amazing Ethereum community.
 - Supports URI Strings on Send Transaction Page.
     - to=[address]

--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -271,7 +271,6 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
         $scope.HDWallet.digitalBitboxSecret = '';
         if (typeof result != "undefined") {
             $scope.HWWalletCreate(result['publicKey'], result['chainCode'], "digitalBitbox", $scope.HDWallet.dPath);
-            $scope.notifier.close();
         } else
             $scope.notifier.danger(error);
     }

--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -249,9 +249,6 @@
         <li id="aria7" tabinex="0" translate="ADD_DigitalBitbox_0a" class="text-danger" ng-hide="isSSL">
           Re-open MyEtherWallet on a secure (SSL) connection
         </li>
-        <li tabinex="0" translate="ADD_DigitalBitbox_0b" class="text-danger" ng-hide="isChrome">
-          Re-open MyEtherWallet using Google Chrome or Opera
-        </li>
       </ol>
       <div class="text-center">
         <br /><br />


### PR DESCRIPTION
An `isChrome` check was removed upstream. Instead of adding it back, I just removed the 'not Chrome' warning in `directives/walletDecryptDrtv.html` because the use of Chrome/Opera is discussed in directions elsewhere (at your site and ours).

`notifier.close()` was also removed upstream, and so removed that line of code.

I took the liberty to add Digital Bitbox to the README.md. There is a link in the README.md: https://myetherwallet.groovehq.com/knowledge_base/topics/hardware-wallet-recommends. Is it possible to add us there after your team and customers feel comfortable with the Digital Bitbox? Same for the webpage (and image in myetherwallet.com linking to it): https://myetherwallet.groovehq.com/knowledge_base/topics/protecting-yourself-and-your-funds.

Referring to #581 - our latest firmware was tested successfully with www.myetherwallet.com

Thanks again for the great work.