### PR TITLE
Change MDA token address

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -420,7 +420,7 @@
     "type":"default"
   },
   {
-    "address":"0xd0b171Eb0b0F2CbD35cCD97cDC5EDC3ffe4871aa",
+    "address":"0x51DB5Ad35C671a87207d88fC11d593AC0C8415bd",
     "symbol":"MDA",
     "decimal":18,
     "type":"default"


### PR DESCRIPTION
Deployed a new version of this token (old one never had transfers enabled). Not yet distributed to donors of the Moeda project.

Can't prove ownership of the token directly, because it was deployed by a [contract](https://etherscan.io/address/0xd0b171Eb0b0F2CbD35cCD97cDC5EDC3ffe4871aa#readContract), but I own the private key for the address pointed to by the `owner` property of [the contract that deployed the token](https://etherscan.io/address/0x4870e705a3def9dda6da7a953d1cd3ccedd08573#readContract). I used your software to sign the message for simplicity.

    {
      "address": "0x003f7b6469bb856ddddbb5b8a8002b0fc6da3009",
      "msg": "I verify that Erik Mossberg may update the MDA token to 0x51DB5Ad35C671a87207d88fC11d593AC0C8415bd",
      "sig":"0x92c675816b6f68fcf1948abcb0059b09415dbae9f0d1166b4a8044941f6332b233f9faf5705217dbe4e9455c135f9ed1e03de6b9805ed1dc734f9fef33111ac91c",
      "version": "2"
    }