### PR TITLE
Add POE Token to defaults + README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ If you want to help contribute, here's what you need to know to get it up and ru
 - Both the Chrome Extension and the MyEtherWallet.com are compiling from the same codebase. This code is found in the `app` folder. Don't touch the `dist` or `chrome-extension` folders.
 - We use angular and bootstrap. We used to use jQuery and Bootstrap until it was converted in April 2016. If you wonder why some things are set up funky, that's why.
 - The mercury branch is currently the active development branch. We then push the dist folder live to gh-pages, which then gets served to MyEtherWallet.com.
-- We use npm / gulp for compiling. There is a lot of stuff happening in the compliation.
-- Old node setups can be found in in `json_relay_node` (node.js) & `json_relay_php` (php). These are great resources for developers looking to get started and launch a public node on a $40 linode instance.
+- We use npm / gulp for compiling. There is a lot of stuff happening in the compilation.
+- Old node setups can be found in `json_relay_node` (node.js) & `json_relay_php` (php). These are great resources for developers looking to get started and launch a public node on a $40 linode instance.
 
 **Getting Started**
 

--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -564,6 +564,12 @@
     "type":"default"
   },
   {
+    "address":"0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
+    "symbol":"POE",
+    "decimal":8,
+    "type":"default"
+  },
+  {
     "address":"0x226bb599a12C826476e3A771454697EA52E9E220",
     "symbol":"PRO",
     "decimal":8,


### PR DESCRIPTION
Just adding the POE token.

When I ran `npm run dev` a whole lot of files were created / updated, dunno what went on there but just in case I'm only committing `app/scripts/tokens/ethTokens.json`.

Running `npm run dist` on the other hand just modified the package-lock.json, removing the `requires": true,` line. Didn't commit that either.