### PR TITLE
Include IKB

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -360,6 +360,12 @@
     "type":"default"
   },
   {
+    "address":"0x88AE96845e157558ef59e9Ff90E766E22E480390",
+    "symbol":"IKB",
+    "decimal":0,
+    "type":"default"
+  },
+  {
     "address":"0xED19698C0abdE8635413aE7AD7224DF6ee30bF22",
     "symbol":"IMT",
     "decimal":0,


### PR DESCRIPTION
IKB is a token representing editions of artworks titled "Digital Zones of Immaterial Pictorial Sensibility." The project launched on August 30 2017 at InterAccess Media Arts Centre in Toronto. Token is ERC-20 compliant and contains unique features outlined in white paper: https://github.com/mitchellfchan/IKB/blob/master/Digital-Zones-Of-Immaterial-Pictorial-Sensibility-Blue-Paper.pdf