### PR TITLE
Token State Issue Fix and Misc Bugfixes

### DIFF
--- a/app/includes/sendTx-content.tpl
+++ b/app/includes/sendTx-content.tpl
@@ -129,7 +129,7 @@
       </div>
     </div>
 
-    <div class="row form-group" ng-show="showRaw">
+    <div class="row form-group" ng-show="rootScopeShowRawTx">
       <div class="col-sm-6">
         <label translate="SEND_raw"> Raw Transaction </label>
         <textarea class="form-control" rows="4" readonly >{{rawTx}}</textarea>
@@ -140,7 +140,7 @@
       </div>
     </div>
 
-    <div class="clearfix form-group" ng-show="showRaw">
+    <div class="clearfix form-group" ng-show="rootScopeShowRawTx">
       <a class="btn btn-primary btn-block col-sm-11" data-toggle="modal" data-target="#sendTransaction" translate="SEND_trans"> Send Transaction </a>
     </div>
   </div>

--- a/app/scripts/controllers/sendTxCtrl.js
+++ b/app/scripts/controllers/sendTxCtrl.js
@@ -1,12 +1,12 @@
 'use strict';
-var sendTxCtrl = function($scope, $sce, walletService) {
+var sendTxCtrl = function($scope, $sce, walletService, $rootScope) {
     $scope.tx = {};
     $scope.ajaxReq = ajaxReq;
     $scope.unitReadable = ajaxReq.type;
     $scope.sendTxModal = new Modal(document.getElementById('sendTransaction'));
     walletService.wallet = null;
     walletService.password = '';
-    $scope.showAdvance = $scope.showRaw = false;
+    $scope.showAdvance = $rootScope.rootScopeShowRawTx = false;
     $scope.dropdownEnabled = true;
     $scope.Validator = Validator;
     $scope.gasLimitChanged = false;
@@ -122,7 +122,7 @@ var sendTxCtrl = function($scope, $sce, walletService) {
         }
     }, true);
     $scope.$watch('tx', function(newValue, oldValue) {
-        $scope.showRaw = false;
+        $rootScope.rootScopeShowRawTx = false;
         if (oldValue.sendMode && oldValue.sendMode != newValue.sendMode && newValue.sendMode == 'ether') {
             $scope.tx.data = globalFuncs.urlGet('data') == null ? "" : globalFuncs.urlGet('data');
             $scope.tx.gasLimit = globalFuncs.defaultTxGasLimit;
@@ -224,9 +224,9 @@ var sendTxCtrl = function($scope, $sce, walletService) {
             if (!rawTx.isError) {
                 $scope.rawTx = rawTx.rawTx;
                 $scope.signedTx = rawTx.signedTx;
-                $scope.showRaw = true;
+                $rootScope.rootScopeShowRawTx = true;
             } else {
-                $scope.showRaw = false;
+                $rootScope.rootScopeShowRawTx = false;
                 $scope.notifier.danger(rawTx.error);
             }
             if (!$scope.$$phase) $scope.$apply();
@@ -258,7 +258,7 @@ var sendTxCtrl = function($scope, $sce, walletService) {
                     $scope.tx.unit = resp.unit;
                     $scope.tx.value = resp.value;
                 } else {
-                    $scope.showRaw = false;
+                    $rootScope.rootScopeShowRawTx = false;
                     $scope.notifier.danger(resp.error);
                 }
             });

--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -1,5 +1,4 @@
 'use strict';
-var hasSetInitialNetwork = false  
 var tabsCtrl = function($scope, globalService, $translate, $sce) {
     $scope.gService = globalService;
     $scope.tabNames = $scope.gService.tabs;
@@ -49,13 +48,31 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
     setGasValues();
     $scope.gasChanged();
 
+    function makeNewNode(key) {
+      var curNode;
+      if ($scope.nodeList[key]) {
+        curNode = $scope.nodeList[key];
+      } else {
+        curNode = $scope.nodeList[$scope.defaultNodeKey];
+      }
+      return curNode;
+    }
 
+    var networkHasChanged = false;
     $scope.changeNode = function(key) {
-        if ($scope.nodeList[key]) {
-            $scope.curNode = $scope.nodeList[key];
+        var newNode = makeNewNode(key);
+        if (!$scope.curNode) {
+          networkHasChanged = false;
+          $scope.curNode = newNode;
         } else {
-            $scope.curNode = $scope.nodeList[$scope.defaultNodeKey];
+          if ($scope.curNode.type !== newNode.type) {
+            networkHasChanged = true;
+          } else {
+            networkHasChanged = false;
+          }
+          $scope.curNode = newNode;
         }
+
         $scope.dropdownNode = false;
         Token.popTokens = $scope.curNode.tokenList;
         ajaxReq['key'] = key;
@@ -77,7 +94,7 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
                 $scope.notifier.info( globalFuncs.successMsgs[5] + '— Now, check the URL: <strong>' + window.location.href + '.</strong> <br /> Network: <strong>' + $scope.nodeType + ' </strong> provided by <strong>' + $scope.nodeService + '.</strong>', 5000)
             }
         });
-        hasSetInitialNetwork ? window.setTimeout(function() {location.reload() }, 250) : hasSetInitialNetwork = true
+        networkHasChanged && window.setTimeout(function() {location.reload() }, 250)
     }
     $scope.checkNodeUrl = function(nodeUrl) {
         return $scope.Validator.isValidURL(nodeUrl);

--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -1,4 +1,5 @@
 'use strict';
+var hasSetInitialNetwork = false  
 var tabsCtrl = function($scope, globalService, $translate, $sce) {
     $scope.gService = globalService;
     $scope.tabNames = $scope.gService.tabs;
@@ -76,6 +77,7 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
                 $scope.notifier.info( globalFuncs.successMsgs[5] + '— Now, check the URL: <strong>' + window.location.href + '.</strong> <br /> Network: <strong>' + $scope.nodeType + ' </strong> provided by <strong>' + $scope.nodeService + '.</strong>', 5000)
             }
         });
+        hasSetInitialNetwork ? window.setTimeout(function() {location.reload() }, 250) : hasSetInitialNetwork = true
     }
     $scope.checkNodeUrl = function(nodeUrl) {
         return $scope.Validator.isValidURL(nodeUrl);

--- a/app/scripts/controllers/walletBalanceCtrl.js
+++ b/app/scripts/controllers/walletBalanceCtrl.js
@@ -1,25 +1,25 @@
 'use strict';
-var walletBalanceCtrl = function ($scope, $sce) {
+var walletBalanceCtrl = function($scope, $sce) {
   $scope.ajaxReq = ajaxReq;
   $scope.tokensLoaded = false;
   $scope.localToken = {
-    contractAdd: '',
-    symbol: '',
-    decimals: '',
-    type: 'custom'
+    contractAdd: "",
+    symbol: "",
+    decimals: "",
+    type: "custom",
   };
 
   $scope.slide = 3;
 
   $scope.customTokenField = false;
-  $scope.saveTokenToLocal = function () {
-    globalFuncs.saveTokenToLocal($scope.localToken, function (data) {
+  $scope.saveTokenToLocal = function() {
+    globalFuncs.saveTokenToLocal($scope.localToken, function(data) {
       if (!data.error) {
         $scope.localToken = {
-          contractAdd: '',
-          symbol: '',
-          decimals: '',
-          type: 'custom'
+          contractAdd: "",
+          symbol: "",
+          decimals: "",
+          type: "custom"
         };
         $scope.wallet.setTokens();
         $scope.validateLocalToken = $sce.trustAsHtml('');
@@ -28,49 +28,47 @@ var walletBalanceCtrl = function ($scope, $sce) {
         $scope.notifier.danger(data.msg);
       }
     });
-  };
-
-
-
+  }
 
   /*
-    $scope.$watch('wallet', function() {
-        if ($scope.wallet) $scope.reverseLookup();
-    });
+  $scope.$watch('wallet', function() {
+      if ($scope.wallet) $scope.reverseLookup();
+  });
 
-    $scope.reverseLookup = function() {
-        var _ens = new ens();
-        _ens.getName($scope.wallet.getAddressString().substring(2) + '.addr.reverse', function(data) {
-            if (data.error) uiFuncs.notifier.danger(data.msg);
-            else if (data.data == '0x') {
-                $scope.showens = false;
-            } else {
-                $scope.ensAddress = data.data;
-                $scope.showens = true;
-            }
-        });
-    }
-    */
+  $scope.reverseLookup = function() {
+      var _ens = new ens();
+      _ens.getName($scope.wallet.getAddressString().substring(2) + '.addr.reverse', function(data) {
+          if (data.error) uiFuncs.notifier.danger(data.msg);
+          else if (data.data == '0x') {
+              $scope.showens = false;
+          } else {
+              $scope.ensAddress = data.data;
+              $scope.showens = true;
+          }
+      });
+  }
+  */
 
   $scope.removeTokenFromLocal = function(tokensymbol) {
     globalFuncs.removeTokenFromLocal(tokensymbol, $scope.wallet.tokenObjs);
-  };
+  }
 
   $scope.showDisplayOnTrezor = function() {
-    return $scope.wallet != null && $scope.wallet.hwType === 'trezor';
-  };
+    return ($scope.wallet != null && $scope.wallet.hwType === 'trezor');
+  }
 
   $scope.displayOnTrezor = function() {
     TrezorConnect.ethereumGetAddress($scope.wallet.path, function() {});
-  };
+  }
 
   $scope.showDisplayOnLedger = function() {
-    return $scope.wallet != null && $scope.wallet.hwType === 'ledger';
-  };
+    return ($scope.wallet != null && $scope.wallet.hwType === 'ledger');
+  }
 
   $scope.displayOnLedger = function() {
     var app = new ledgerEth($scope.wallet.getHWTransport());
-    app.getAddress($scope.wallet.path, function() {}, true, false);
-  };
+    app.getAddress($scope.wallet.path, function(){}, true, false);
+  }
+
 };
 module.exports = walletBalanceCtrl;

--- a/app/scripts/controllers/walletBalanceCtrl.js
+++ b/app/scripts/controllers/walletBalanceCtrl.js
@@ -1,5 +1,5 @@
 'use strict';
-var walletBalanceCtrl = function($scope, $sce) {
+var walletBalanceCtrl = function($scope, $sce, $rootScope) {
     $scope.ajaxReq = ajaxReq;
     $scope.tokensLoaded = false;
     $scope.localToken = {
@@ -52,6 +52,7 @@ var walletBalanceCtrl = function($scope, $sce) {
 
     $scope.removeTokenFromLocal = function(tokensymbol) {
         globalFuncs.removeTokenFromLocal(tokensymbol, $scope.wallet.tokenObjs);
+        $rootScope.rootScopeShowRawTx = false;
     }
 
     $scope.showDisplayOnTrezor = function() {

--- a/app/scripts/controllers/walletBalanceCtrl.js
+++ b/app/scripts/controllers/walletBalanceCtrl.js
@@ -1,15 +1,5 @@
 'use strict';
 var walletBalanceCtrl = function ($scope, $sce) {
-  console.log($scope.wallet)
-  var defaultTokensAndNetworkType
-  // TODO: Everyone check this now especially Daniel
-  try {
-    defaultTokensAndNetworkType = globalFuncs.getDefaultTokensAndNetworkType()
-  } catch (e) {
-    console.log(e)
-    return $scope.notifier.danger(e.message);
-  }
-  console.log(defaultTokensAndNetworkType)
   $scope.ajaxReq = ajaxReq;
   $scope.tokensLoaded = false;
   $scope.localToken = {
@@ -19,13 +9,11 @@ var walletBalanceCtrl = function ($scope, $sce) {
     type: 'custom'
   };
 
-
   $scope.slide = 3;
 
   $scope.customTokenField = false;
   $scope.saveTokenToLocal = function () {
     globalFuncs.saveTokenToLocal($scope.localToken, function (data) {
-      console.log(data)
       if (!data.error) {
         $scope.localToken = {
           contractAdd: '',

--- a/app/scripts/controllers/walletBalanceCtrl.js
+++ b/app/scripts/controllers/walletBalanceCtrl.js
@@ -15,6 +15,7 @@ var walletBalanceCtrl = function($scope, $sce) {
     $scope.saveTokenToLocal = function() {
         globalFuncs.saveTokenToLocal($scope.localToken, function(data) {
             if (!data.error) {
+                $scope.addressDrtv.ensAddressField = "";
                 $scope.localToken = {
                     contractAdd: "",
                     symbol: "",

--- a/app/scripts/controllers/walletBalanceCtrl.js
+++ b/app/scripts/controllers/walletBalanceCtrl.js
@@ -16,7 +16,6 @@ var walletBalanceCtrl = function ($scope, $sce) {
     contractAdd: '',
     symbol: '',
     decimals: '',
-    network: defaultTokensAndNetworkType.networkType,
     type: 'custom'
   };
 
@@ -31,7 +30,6 @@ var walletBalanceCtrl = function ($scope, $sce) {
         $scope.localToken = {
           contractAdd: '',
           symbol: '',
-          network: defaultTokensAndNetworkType.networkType,    
           decimals: '',
           type: 'custom'
         };
@@ -45,8 +43,8 @@ var walletBalanceCtrl = function ($scope, $sce) {
   };
 
 
-  
-  
+
+
   /*
     $scope.$watch('wallet', function() {
         if ($scope.wallet) $scope.reverseLookup();

--- a/app/scripts/controllers/walletBalanceCtrl.js
+++ b/app/scripts/controllers/walletBalanceCtrl.js
@@ -1,36 +1,53 @@
 'use strict';
-var walletBalanceCtrl = function($scope, $sce) {
-    $scope.ajaxReq = ajaxReq;
-    $scope.tokensLoaded = false;
-    $scope.localToken = {
-        contractAdd: "",
-        symbol: "",
-        decimals: "",
-        type: "custom",
-    };
+var walletBalanceCtrl = function ($scope, $sce) {
+  console.log($scope.wallet)
+  var defaultTokensAndNetworkType
+  // TODO: Everyone check this now especially Daniel
+  try {
+    defaultTokensAndNetworkType = globalFuncs.getDefaultTokensAndNetworkType()
+  } catch (e) {
+    console.log(e)
+    return $scope.notifier.danger(e.message);
+  }
+  console.log(defaultTokensAndNetworkType)
+  $scope.ajaxReq = ajaxReq;
+  $scope.tokensLoaded = false;
+  $scope.localToken = {
+    contractAdd: '',
+    symbol: '',
+    decimals: '',
+    network: defaultTokensAndNetworkType.networkType,
+    type: 'custom'
+  };
 
-    $scope.slide = 3;
 
-    $scope.customTokenField = false;
-    $scope.saveTokenToLocal = function() {
-        globalFuncs.saveTokenToLocal($scope.localToken, function(data) {
-            if (!data.error) {
-                $scope.localToken = {
-                    contractAdd: "",
-                    symbol: "",
-                    decimals: "",
-                    type: "custom"
-                };
-                $scope.wallet.setTokens();
-                $scope.validateLocalToken = $sce.trustAsHtml('');
-                $scope.customTokenField = false;
-            } else {
-                $scope.notifier.danger(data.msg);
-            }
-        });
-    }
+  $scope.slide = 3;
 
-    /*
+  $scope.customTokenField = false;
+  $scope.saveTokenToLocal = function () {
+    globalFuncs.saveTokenToLocal($scope.localToken, function (data) {
+      console.log(data)
+      if (!data.error) {
+        $scope.localToken = {
+          contractAdd: '',
+          symbol: '',
+          network: defaultTokensAndNetworkType.networkType,    
+          decimals: '',
+          type: 'custom'
+        };
+        $scope.wallet.setTokens();
+        $scope.validateLocalToken = $sce.trustAsHtml('');
+        $scope.customTokenField = false;
+      } else {
+        $scope.notifier.danger(data.msg);
+      }
+    });
+  };
+
+
+  
+  
+  /*
     $scope.$watch('wallet', function() {
         if ($scope.wallet) $scope.reverseLookup();
     });
@@ -49,26 +66,25 @@ var walletBalanceCtrl = function($scope, $sce) {
     }
     */
 
-    $scope.removeTokenFromLocal = function(tokensymbol) {
-        globalFuncs.removeTokenFromLocal(tokensymbol, $scope.wallet.tokenObjs);
-    }
+  $scope.removeTokenFromLocal = function(tokensymbol) {
+    globalFuncs.removeTokenFromLocal(tokensymbol, $scope.wallet.tokenObjs);
+  };
 
-    $scope.showDisplayOnTrezor = function() {
-        return ($scope.wallet != null && $scope.wallet.hwType === 'trezor');
-    }
+  $scope.showDisplayOnTrezor = function() {
+    return $scope.wallet != null && $scope.wallet.hwType === 'trezor';
+  };
 
-    $scope.displayOnTrezor = function() {
-        TrezorConnect.ethereumGetAddress($scope.wallet.path, function() {});
-    }
+  $scope.displayOnTrezor = function() {
+    TrezorConnect.ethereumGetAddress($scope.wallet.path, function() {});
+  };
 
-    $scope.showDisplayOnLedger = function() {
-        return ($scope.wallet != null && $scope.wallet.hwType === 'ledger');
-    }
+  $scope.showDisplayOnLedger = function() {
+    return $scope.wallet != null && $scope.wallet.hwType === 'ledger';
+  };
 
-    $scope.displayOnLedger = function() {
-        var app = new ledgerEth($scope.wallet.getHWTransport());
-        app.getAddress($scope.wallet.path, function(){}, true, false);
-    }
-
+  $scope.displayOnLedger = function() {
+    var app = new ledgerEth($scope.wallet.getHWTransport());
+    app.getAddress($scope.wallet.path, function() {}, true, false);
+  };
 };
 module.exports = walletBalanceCtrl;

--- a/app/scripts/controllers/walletBalanceCtrl.js
+++ b/app/scripts/controllers/walletBalanceCtrl.js
@@ -1,39 +1,36 @@
 'use strict';
-var walletBalanceCtrl = function ($scope, $sce) {
-  $scope.ajaxReq = ajaxReq;
-  $scope.tokensLoaded = false;
-  $scope.localToken = {
-    contractAdd: '',
-    symbol: '',
-    decimals: '',
-    type: 'custom'
-  };
+var walletBalanceCtrl = function($scope, $sce) {
+    $scope.ajaxReq = ajaxReq;
+    $scope.tokensLoaded = false;
+    $scope.localToken = {
+        contractAdd: "",
+        symbol: "",
+        decimals: "",
+        type: "custom",
+    };
 
-  $scope.slide = 3;
+    $scope.slide = 3;
 
-  $scope.customTokenField = false;
-  $scope.saveTokenToLocal = function () {
-    globalFuncs.saveTokenToLocal($scope.localToken, function (data) {
-      if (!data.error) {
-        $scope.localToken = {
-          contractAdd: '',
-          symbol: '',
-          decimals: '',
-          type: 'custom'
-        };
-        $scope.wallet.setTokens();
-        $scope.validateLocalToken = $sce.trustAsHtml('');
-        $scope.customTokenField = false;
-      } else {
-        $scope.notifier.danger(data.msg);
-      }
-    });
-  };
+    $scope.customTokenField = false;
+    $scope.saveTokenToLocal = function() {
+        globalFuncs.saveTokenToLocal($scope.localToken, function(data) {
+            if (!data.error) {
+                $scope.localToken = {
+                    contractAdd: "",
+                    symbol: "",
+                    decimals: "",
+                    type: "custom"
+                };
+                $scope.wallet.setTokens();
+                $scope.validateLocalToken = $sce.trustAsHtml('');
+                $scope.customTokenField = false;
+            } else {
+                $scope.notifier.danger(data.msg);
+            }
+        });
+    }
 
-
-
-
-  /*
+    /*
     $scope.$watch('wallet', function() {
         if ($scope.wallet) $scope.reverseLookup();
     });
@@ -52,25 +49,26 @@ var walletBalanceCtrl = function ($scope, $sce) {
     }
     */
 
-  $scope.removeTokenFromLocal = function(tokensymbol) {
-    globalFuncs.removeTokenFromLocal(tokensymbol, $scope.wallet.tokenObjs);
-  };
+    $scope.removeTokenFromLocal = function(tokensymbol) {
+        globalFuncs.removeTokenFromLocal(tokensymbol, $scope.wallet.tokenObjs);
+    }
 
-  $scope.showDisplayOnTrezor = function() {
-    return $scope.wallet != null && $scope.wallet.hwType === 'trezor';
-  };
+    $scope.showDisplayOnTrezor = function() {
+        return ($scope.wallet != null && $scope.wallet.hwType === 'trezor');
+    }
 
-  $scope.displayOnTrezor = function() {
-    TrezorConnect.ethereumGetAddress($scope.wallet.path, function() {});
-  };
+    $scope.displayOnTrezor = function() {
+        TrezorConnect.ethereumGetAddress($scope.wallet.path, function() {});
+    }
 
-  $scope.showDisplayOnLedger = function() {
-    return $scope.wallet != null && $scope.wallet.hwType === 'ledger';
-  };
+    $scope.showDisplayOnLedger = function() {
+        return ($scope.wallet != null && $scope.wallet.hwType === 'ledger');
+    }
 
-  $scope.displayOnLedger = function() {
-    var app = new ledgerEth($scope.wallet.getHWTransport());
-    app.getAddress($scope.wallet.path, function() {}, true, false);
-  };
+    $scope.displayOnLedger = function() {
+        var app = new ledgerEth($scope.wallet.getHWTransport());
+        app.getAddress($scope.wallet.path, function(){}, true, false);
+    }
+
 };
 module.exports = walletBalanceCtrl;

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -202,9 +202,7 @@ function getFromLS(key, errorMsg) {
     else {
         return JSON.parse(localStorageItemString)
     }
-
 }
-
 
 globalFuncs.getDefaultTokensAndNetworkType =  function getDefaultTokensAndNetworkType() {
     var defaultNodes = require('./nodes').nodeList;

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -318,7 +318,7 @@ globalFuncs.saveTokenToLocal = function(localToken, callback) {
         // catch if CONTRACT ADDRESS is already in storedTokens
         for (var i = 0; i < storedTokens.length; i++){
             if (storedTokens[i].contractAddress.toLowerCase().replace(/ /g, '') === localToken.contractAdd.toLowerCase().replace(/ /g, '')) {
-              throw Error('ERROR: Unable to add a custom token with the same contract address as an existing custom token')
+              throw Error('ERROR: Unable to add custom token. It has the same address as custom token ' + storedTokens[i].symbol + '.')
             }
         }
 

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -207,8 +207,7 @@ function getFromLS(key, errorMsg) {
 
 
 globalFuncs.getDefaultTokensAndNetworkType =  function getDefaultTokensAndNetworkType() {
-    console.log('0')
-    var defaultNodes = require('./nodes').nodeList
+    var defaultNodes = require('./nodes').nodeList;
 
     var tokenMappings = {
         'eth': require('./tokens/ethTokens.json'),
@@ -216,48 +215,42 @@ globalFuncs.getDefaultTokensAndNetworkType =  function getDefaultTokensAndNetwor
         'rop': require('./tokens/ropstenTokens.json'),
         'kov': require('./tokens/kovanTokens.json'),
         'rin': require('./tokens/rinkebyTokens.json')
-    } 
-    console.log('1')
-    
+    };
+
     var nodeErrMsg = 'Node does not exist, contact support@myetherwallet.com CODE:localstorageNodeMissing'
-
     // localStorage selected node
-    var currentNodeKey = getFromLS("curNode", nodeErrMsg).key
+    var currentNodeKey = getFromLS("curNode", nodeErrMsg).key;
     // custom nodes in local storage
-    console.log('1.5')
-    var customLocalNodes = getFromLS("localNodes") || []
+    var customLocalNodes = getFromLS("localNodes") || [];
 
-    var customNodeNetworkType = currentNodeKey.split('_')[1]
+    var customNodeNetworkType = currentNodeKey.split('_')[1];
 
     var isCustomNode = !!customLocalNodes.find(function (currentLocalCustomNode) {
       return currentLocalCustomNode.options === customNodeNetworkType
-    })
-    
+    });
+
     var defaultNode;
     var firstCustomNodeWithMatchingNetwork;
-    console.log('2')
+    var defaultTokens;
+
     if (isCustomNode) {
       // NOTE: Different curNode value structure for default nodes and custom nodes. This will work because we are checking to make sure we are a custom node first.
 
       firstCustomNodeWithMatchingNetwork = customLocalNodes.find(function (currentLocalCustomNode) {
         return currentLocalCustomNode.options === customNodeNetworkType
-      })
-      
+      });
+
       // if the reference the custom local node is invalid, throw
       if (!firstCustomNodeWithMatchingNetwork) {
         throw Error("Custom Local Node does not exist. Please clear local storage, and re-input your custom node.")
       }
     } else {
-      defaultNode = defaultNodes[currentNodeKey]
+      defaultNode = defaultNodes[currentNodeKey];
       if (!defaultNode) {
         throw Error("Default Node does not exist. Please clear local storage and try again.")
       }
     }
-    console.log('3')
-    
-    var defaultTokens;
-    console.log(isCustomNode)
-    
+
     if (isCustomNode) {
       // tokenMappings maps localStorage custom node key to corresponding default tokens of network. If we are unable to retrieve the default tokens of the custom network, we return an empty array.
       defaultTokens = tokenMappings[firstCustomNodeWithMatchingNetwork.options] || []
@@ -265,54 +258,43 @@ globalFuncs.getDefaultTokensAndNetworkType =  function getDefaultTokensAndNetwor
     else {
       defaultTokens = defaultNode.tokenList
     }
-  
+
     return {
       defaultTokens: defaultTokens,
       networkType: isCustomNode ? firstCustomNodeWithMatchingNetwork.options : defaultNode.name.toLowerCase(),
       isCustomNode: isCustomNode
     }
 }
-  
+
 globalFuncs.saveTokenToLocal = function(localToken, callback) {
     try {
-        if (!ethFuncs.validateEtherAddress(localToken.contractAdd)) throw globalFuncs.errorMsgs[5];
-        else if (!globalFuncs.isNumeric(localToken.decimals) || parseFloat(localToken.decimals) < 0) throw globalFuncs.errorMsgs[7];
-        else if (!globalFuncs.isAlphaNumeric(localToken.symbol) || localToken.symbol == "") throw globalFuncs.errorMsgs[19];
+        if (!ethFuncs.validateEtherAddress(localToken.contractAdd)) {throw globalFuncs.errorMsgs[5]}
+        else if (!globalFuncs.isNumeric(localToken.decimals) || parseFloat(localToken.decimals) < 0) {throw globalFuncs.errorMsgs[7]}
+        else if (!globalFuncs.isAlphaNumeric(localToken.symbol) || localToken.symbol == "") {throw globalFuncs.errorMsgs[19]}
         var storedTokens = globalFuncs.localStorage.getItem("localTokens", null) != null ? JSON.parse(globalFuncs.localStorage.getItem("localTokens")) : [];
 
         //catch local storage bug when user adds a duplicate custom token
         for (var i = 0; i < storedTokens.length; i++){
             if (storedTokens[i].symbol.toLowerCase().replace(/ /g, '') === localToken.symbol.toLowerCase().replace(/ /g, '')) {
-                console.log('throwing error')
               throw Error('ERROR: Unable to add a custom token with the same symbol as an existing custom token')
             }
         }
-        // New default token list gets pushed to site, which conflicts with users already existing custom tokens
-        // Perform diff of default tokens vs custom tokens, remove any conflicting custom tokens
-        // When user adds a custom token thats already in local storage
-        // When user adds a a custom token, thats already a default token (JSON)
-        // CASE 2: needs to be checked vs chainId/network type
-        // CASE 1: QRL_ETC
 
-
-
-        //loop through all node tokens and see if user inputted token matches any in memory token
-        
-
-
-        
         storedTokens.push({
             contractAddress: localToken.contractAdd,
             symbol: localToken.symbol,
             decimal: parseInt(localToken.decimals),
-            type: "custom"
+            type: "custom",
+            network: globalFuncs.getDefaultTokensAndNetworkType().networkType
         });
-        globalFuncs.localStorage.setItem("localTokens", JSON.stringify(storedTokens));
+
+        localStorage.setItem("localTokens", JSON.stringify(storedTokens));
+
         callback({
-            error: false
+          error: false
         });
+
     } catch (e) {
-        console.log('Error', e)
         callback({
             error: true,
             msg: e.message

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -280,6 +280,27 @@ globalFuncs.doesTokenExistInDefaultTokens = function(token, defaultTokensAndNetw
   return false
 };
 
+function checkDuplicateTokenAddress(tokenOne, tokenTwo, currentNetwork) {
+  var hasNetwork = tokenTwo.network;
+  if (hasNetwork) {
+    return tokenTwo.network === currentNetwork && tokenTwo.contractAdd === tokenOne.address
+  } else {
+    return tokenTwo.contractAdd === tokenOne.address
+  }
+}
+
+globalFuncs.doesTokenAddressExistInDefaultTokenAddresses = function(token, defaultTokensAndNetworkType) {
+  for (var i = 0; i < defaultTokensAndNetworkType.defaultTokens.length; i++) {
+    var currentDefaultToken = defaultTokensAndNetworkType.defaultTokens[i];
+    var isDuplicateToken = checkDuplicateTokenAddress(currentDefaultToken, token, defaultTokensAndNetworkType.networkType);
+    // do not simplify to return isDuplicateToken
+    if (isDuplicateToken) {
+      return true
+    }
+  }
+  return false
+};
+
 globalFuncs.saveTokenToLocal = function(localToken, callback) {
     try {
         if (!ethFuncs.validateEtherAddress(localToken.contractAdd)) {throw globalFuncs.errorMsgs[5]}
@@ -287,20 +308,33 @@ globalFuncs.saveTokenToLocal = function(localToken, callback) {
         else if (!globalFuncs.isAlphaNumeric(localToken.symbol) || localToken.symbol == "") {throw globalFuncs.errorMsgs[19]}
         var storedTokens = globalFuncs.localStorage.getItem("localTokens", null) != null ? JSON.parse(globalFuncs.localStorage.getItem("localTokens")) : [];
 
-        // catch if already in storedTokens
+        // catch if TOKEN SYMBOL is already in storedTokens
         for (var i = 0; i < storedTokens.length; i++){
             if (storedTokens[i].symbol.toLowerCase().replace(/ /g, '') === localToken.symbol.toLowerCase().replace(/ /g, '')) {
               throw Error('ERROR: Unable to add a custom token with the same symbol as an existing custom token')
             }
         }
 
-        // catch if already in defaultTokens
+        // catch if CONTRACT ADDRESS is already in storedTokens
+        for (var i = 0; i < storedTokens.length; i++){
+            if (storedTokens[i].contractAddress.toLowerCase().replace(/ /g, '') === localToken.contractAdd.toLowerCase().replace(/ /g, '')) {
+              throw Error('ERROR: Unable to add a custom token with the same contract address as an existing custom token')
+            }
+        }
+
         var defaultTokensAndNetworkType = globalFuncs.getDefaultTokensAndNetworkType();
+
+        // catch if TOKEN SYMBOL is already in defaultTokens
         if (globalFuncs.doesTokenExistInDefaultTokens(localToken, defaultTokensAndNetworkType)) {
           throw Error('ERROR: Unable to add a custom token with the same symbol as an existing default token')
         }
 
-        storedTokens.push({
+        // catch if CONTRACT ADDRESS is already in defaultTokens
+        if (globalFuncs.doesTokenAddressExistInDefaultTokenAddresses(localToken, defaultTokensAndNetworkType)) {
+          throw Error('ERROR: Unable to add a custom token with the same contract address as an existing default token')
+        }
+
+      storedTokens.push({
             contractAddress: localToken.contractAdd,
             symbol: localToken.symbol,
             decimal: parseInt(localToken.decimals),

--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -187,13 +187,8 @@ globalFuncs.getRandomBytes = function(num) {
     return ethUtil.crypto.randomBytes(num);
 };
 
-globalFuncs.normalize = function normalize(str) {
-    return str.toLowerCase().replace(/ /g, '')
-  }
-
 function getFromLS(key, errorMsg) {
     var localStorageItemString = globalFuncs.localStorage.getItem(key);
-
     if (!localStorageItemString && errorMsg) {
         throw Error(errorMsg)
     } else if (!localStorageItemString) {

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -130,14 +130,14 @@ app.controller('bulkGenCtrl', ['$scope', bulkGenCtrl]);
 app.controller('decryptWalletCtrl', ['$scope', '$sce', 'walletService', decryptWalletCtrl]);
 app.controller('viewWalletCtrl', ['$scope', 'walletService', viewWalletCtrl]);
 app.controller('txStatusCtrl', ['$scope', txStatusCtrl]);
-app.controller('sendTxCtrl', ['$scope', '$sce', 'walletService', sendTxCtrl]);
+app.controller('sendTxCtrl', ['$scope', '$sce', 'walletService', '$rootScope', sendTxCtrl]);
 app.controller('swapCtrl', ['$scope', '$sce', 'walletService', swapCtrl]);
 app.controller('signMsgCtrl', ['$scope', '$sce', 'walletService', signMsgCtrl]);
 app.controller('contractsCtrl', ['$scope', '$sce', 'walletService', contractsCtrl]);
 app.controller('ensCtrl', ['$scope', '$sce', 'walletService', ensCtrl]);
 app.controller('footerCtrl', ['$scope', 'globalService', footerCtrl]);
 app.controller('offlineTxCtrl', ['$scope', '$sce', 'walletService', offlineTxCtrl]);
-app.controller('walletBalanceCtrl', ['$scope', '$sce', walletBalanceCtrl]);
+app.controller('walletBalanceCtrl', ['$scope', '$sce', '$rootScope', walletBalanceCtrl]);
 app.controller('helpersCtrl', ['$scope', helpersCtrl]);
 if (IS_CX) {
   app.controller('addWalletCtrl', ['$scope', '$sce', addWalletCtrl]);

--- a/app/scripts/myetherwallet.js
+++ b/app/scripts/myetherwallet.js
@@ -41,10 +41,10 @@ Wallet.prototype.setTokens = function () {
 
     var storedTokens = globalFuncs.localStorage.getItem('localTokens', null) != null ? JSON.parse(globalFuncs.localStorage.getItem('localTokens')) : [];
 
-    var conflictTokens = [];
+    var conflictWithDefaultTokens = [];
     for (var e = 0; e < storedTokens.length; e++) {
         if (isDuplicateStoredToken(storedTokens[e], defaultTokensAndNetworkType)) {
-            conflictTokens.push(storedTokens[e]);
+            conflictWithDefaultTokens.push(storedTokens[e]);
             // don't push to tokenObjs if token is default; continue to next element
             continue;
       }
@@ -61,7 +61,7 @@ Wallet.prototype.setTokens = function () {
       this.tokenObjs[this.tokenObjs.length - 1].setBalance();
     }
 
-    removeAllTokenConflicts(conflictTokens, storedTokens)
+    removeAllTokenConflicts(conflictWithDefaultTokens, storedTokens)
 };
 
 function checkDuplicateToken(defaultToken, localStorageToken, currentNetwork) {
@@ -122,15 +122,15 @@ function removeDuplicates(originalArray, objKey) {
 }
 
 function deDupTokens(tokens) {
-  // generic de-dup;
+  // generic de-dup
   var deDupedTokens = deDup(tokens);
   var trimmedByContract = removeDuplicates(deDupedTokens, 'contractAddress');
   var trimmedBySymbol = removeDuplicates(trimmedByContract, 'symbol');
   return trimmedBySymbol
 }
 
-function removeAllTokenConflicts(conflictTokens, storedTokens) {
-  var deConflictedTokens = removeConflictingTokens(conflictTokens, storedTokens);
+function removeAllTokenConflicts(conflictWithDefaultTokens, storedTokens) {
+  var deConflictedTokens = removeConflictingTokens(conflictWithDefaultTokens, storedTokens);
   var deDuplicatedTokens = deDupTokens(deConflictedTokens);
   saveToLocalStorage("localTokens", deDuplicatedTokens)
 }

--- a/app/scripts/myetherwallet.js
+++ b/app/scripts/myetherwallet.js
@@ -43,7 +43,7 @@ Wallet.prototype.setTokens = function () {
 
     var conflictWithDefaultTokens = [];
     for (var e = 0; e < storedTokens.length; e++) {
-        if (isDuplicateStoredToken(storedTokens[e], defaultTokensAndNetworkType)) {
+        if (globalFuncs.doesTokenExistInDefaultTokens(storedTokens[e], defaultTokensAndNetworkType)) {
             conflictWithDefaultTokens.push(storedTokens[e]);
             // don't push to tokenObjs if token is default; continue to next element
             continue;
@@ -63,15 +63,6 @@ Wallet.prototype.setTokens = function () {
 
     removeAllTokenConflicts(conflictWithDefaultTokens, storedTokens)
 };
-
-function checkDuplicateToken(defaultToken, localStorageToken, currentNetwork) {
-    var hasNetwork = localStorageToken.network;
-    if (hasNetwork) {
-        return localStorageToken.network === currentNetwork && localStorageToken.symbol === defaultToken.symbol
-    } else {
-        return localStorageToken.symbol === defaultToken.symbol
-    }
-}
 
 function saveToLocalStorage(key, value) {
   localStorage.setItem(key, JSON.stringify(value))
@@ -133,18 +124,6 @@ function removeAllTokenConflicts(conflictWithDefaultTokens, storedTokens) {
   var deConflictedTokens = removeConflictingTokens(conflictWithDefaultTokens, storedTokens);
   var deDuplicatedTokens = deDupTokens(deConflictedTokens);
   saveToLocalStorage("localTokens", deDuplicatedTokens)
-}
-
-function isDuplicateStoredToken(storedToken, defaultTokensAndNetworkType) {
-    for (var i = 0; i < defaultTokensAndNetworkType.defaultTokens.length; i++) {
-        var currentDefaultToken = defaultTokensAndNetworkType.defaultTokens[i];
-        var isDuplicateToken = checkDuplicateToken(currentDefaultToken, storedToken, defaultTokensAndNetworkType.networkType);
-        // do not simplify to return isDuplicateToken
-        if (isDuplicateToken) {
-            return true
-        }
-    }
-    return false
 }
 
 Wallet.prototype.setBalance = function(callback) {

--- a/app/scripts/myetherwallet.js
+++ b/app/scripts/myetherwallet.js
@@ -90,11 +90,6 @@ function removeConflictingTokens(conflictTokens, storedTokens) {
   return storedTokens
 }
 
-function deDup(list) {
-  var uniq = new Set(list.map(e => JSON.stringify(e)));
-  return Array.from(uniq).map(e => JSON.parse(e));
-}
-
 // https://stackoverflow.com/questions/32238602/javascript-remove-duplicates-of-objects-sharing-same-property-value
 function removeDuplicates(originalArray, objKey) {
   var trimmedArray = [];
@@ -114,8 +109,7 @@ function removeDuplicates(originalArray, objKey) {
 
 function deDupTokens(tokens) {
   // generic de-dup
-  var deDupedTokens = deDup(tokens);
-  var trimmedByContract = removeDuplicates(deDupedTokens, 'contractAddress');
+  var trimmedByContract = removeDuplicates(tokens, 'contractAddress');
   var trimmedBySymbol = removeDuplicates(trimmedByContract, 'symbol');
   return trimmedBySymbol
 }

--- a/app/scripts/myetherwallet.js
+++ b/app/scripts/myetherwallet.js
@@ -107,16 +107,9 @@ function removeDuplicates(originalArray, objKey) {
   return trimmedArray;
 }
 
-function deDupTokens(tokens) {
-  // generic de-dup
-  var trimmedByContract = removeDuplicates(tokens, 'contractAddress');
-  var trimmedBySymbol = removeDuplicates(trimmedByContract, 'symbol');
-  return trimmedBySymbol
-}
-
 function removeAllTokenConflicts(conflictWithDefaultTokens, storedTokens) {
   var deConflictedTokens = removeConflictingTokens(conflictWithDefaultTokens, storedTokens);
-  var deDuplicatedTokens = deDupTokens(deConflictedTokens);
+  var deDuplicatedTokens = removeDuplicates(deConflictedTokens, 'symbol');
   saveToLocalStorage("localTokens", deDuplicatedTokens)
 }
 

--- a/app/scripts/myetherwallet.js
+++ b/app/scripts/myetherwallet.js
@@ -21,6 +21,7 @@ Wallet.generate = function(icapDirect) {
         return new Wallet(ethUtil.crypto.randomBytes(32))
     }
 }
+
 Wallet.prototype.setTokens = function () {
     this.tokenObjs = [];
     var defaultTokensAndNetworkType = globalFuncs.getDefaultTokensAndNetworkType();
@@ -47,20 +48,19 @@ Wallet.prototype.setTokens = function () {
             conflictWithDefaultTokens.push(storedTokens[e]);
             // don't push to tokenObjs if token is default; continue to next element
             continue;
-      }
+        }
 
-      this.tokenObjs.push(
-        new Token(
-          storedTokens[e].contractAddress,
-          this.getAddressString(),
-          globalFuncs.stripTags(storedTokens[e].symbol),
-          storedTokens[e].decimal,
-          storedTokens[e].type,
-        )
-      );
-      this.tokenObjs[this.tokenObjs.length - 1].setBalance();
+        this.tokenObjs.push(
+          new Token(
+            storedTokens[e].contractAddress,
+            this.getAddressString(),
+            globalFuncs.stripTags(storedTokens[e].symbol),
+            storedTokens[e].decimal,
+            storedTokens[e].type,
+          )
+        );
+        this.tokenObjs[this.tokenObjs.length - 1].setBalance();
     }
-
     removeAllTokenConflicts(conflictWithDefaultTokens, storedTokens)
 };
 
@@ -68,26 +68,15 @@ function saveToLocalStorage(key, value) {
   localStorage.setItem(key, JSON.stringify(value))
 }
 
-function removeConflictingTokens(conflictTokens, storedTokens) {
-  for (var i = 0; i < storedTokens.length; i++) {
-    var currentStoredToken = storedTokens[i];
-    for (var e = 0; e < conflictTokens.length; e++) {
-      var currentConflictToken = conflictTokens[e];
-      if (currentConflictToken.network && currentStoredToken.network) {
-        if (
-          currentStoredToken.symbol === currentConflictToken.symbol &&
-          currentStoredToken.network === currentConflictToken.network
-        ) {
-          storedTokens.splice(i, 1);
-        }
-      } else {
-        if (currentStoredToken.symbol === currentConflictToken.symbol) {
-          storedTokens.splice(i, 1);
-        }
+function removeConflictingTokensFromLocalStorage(conflictLocalTokens, localTokens) {
+  for (var i = 0; i < conflictLocalTokens.length; i++) {
+    for (var e = 0; e < localTokens.length; e++) {
+      if (conflictLocalTokens[i] === localTokens[e]) {
+        localTokens.splice(e, 1);
       }
     }
   }
-  return storedTokens
+  return localTokens;
 }
 
 // https://stackoverflow.com/questions/32238602/javascript-remove-duplicates-of-objects-sharing-same-property-value
@@ -107,8 +96,8 @@ function removeDuplicates(originalArray, objKey) {
   return trimmedArray;
 }
 
-function removeAllTokenConflicts(conflictWithDefaultTokens, storedTokens) {
-  var deConflictedTokens = removeConflictingTokens(conflictWithDefaultTokens, storedTokens);
+function removeAllTokenConflicts(conflictWithDefaultTokens, localTokens) {
+  var deConflictedTokens = removeConflictingTokensFromLocalStorage(conflictWithDefaultTokens, localTokens);
   var deDuplicatedTokens = removeDuplicates(deConflictedTokens, 'symbol');
   saveToLocalStorage("localTokens", deDuplicatedTokens)
 }

--- a/app/scripts/tokenlib.js
+++ b/app/scripts/tokenlib.js
@@ -1,12 +1,11 @@
 'use strict';
-var Token = function(contractAddress, userAddress, symbol, decimal, type, network) {
+var Token = function(contractAddress, userAddress, symbol, decimal, type) {
     this.contractAddress = contractAddress;
     this.userAddress = userAddress;
     this.symbol = symbol;
     this.decimal = decimal;
     this.type = type;
     this.balance = "loading";
-    this.network = network;
 };
 Token.balanceHex = "0x70a08231";
 Token.transferHex = "0xa9059cbb";

--- a/app/scripts/tokenlib.js
+++ b/app/scripts/tokenlib.js
@@ -1,11 +1,12 @@
 'use strict';
-var Token = function(contractAddress, userAddress, symbol, decimal, type) {
+var Token = function(contractAddress, userAddress, symbol, decimal, type, network) {
     this.contractAddress = contractAddress;
     this.userAddress = userAddress;
     this.symbol = symbol;
     this.decimal = decimal;
     this.type = type;
     this.balance = "loading";
+    this.network = network;
 };
 Token.balanceHex = "0x70a08231";
 Token.transferHex = "0xa9059cbb";


### PR DESCRIPTION
## Bugs

1.   User could input duplicate tokens via custom token form. This could cause a corruption to state that results in potentially incorrect tokens being sent via subsequent transactions.
2.   User could cause unexpected state to occur by deleting a custom token that has a corresponding default token. This could cause a corruption to state that results in potentially incorrect tokens being sent via subsequent transactions. 


## Methods of Encounter
1. User adds a custom token that is already in local storage.
2. User adds a a custom token that is already in the default token list.
3. MEW updates the default token list with a token(s) that conflicts with a user’s existing custom token(s).

## Solutions
1. Prevent user from adding a custom token with the same symbol and network as an existing default or custom token.
2. Remove custom tokens that conflict with default tokens (matching symbol or contract address).
3. De-dup custom tokens that match with another custom token (only possible before this PR, as (1) prevents this from happening in the future).
4. Prevent user from adding a custom token with the same contract address and network as an existing default or custom token.

##### Additionally, a handful of additional fixes were implemented alongside the token state corruption fix:
1. Network type is now set on new custom tokens.
2. Node selection change will cause a refresh when networks change (to ensure clean state).
3. Deleting a custom token will hide rawTx/signedTx textAreas (rootScope hack, but doesn’t introduce significant complexity).
4. Reset contractAddress input after successfully saving a token.
