### PR TITLE
Add SingularDTV derivation to mnemonic paths.

### DIFF
--- a/app/includes/addWallet.tpl
+++ b/app/includes/addWallet.tpl
@@ -258,6 +258,20 @@
             <tr>
               <td>
                 <label class="radio">
+                  <input aria-describedby="Path: SingularDTV {{HDWallet.singularDTVPath}}"
+                         ng-change="onHDDPathChange()"
+                         ng-model="HDWallet.dPath"
+                         type="radio"
+                         value="{{HDWallet.singularDTVPath}}"/>
+                  <span ng-bind="HDWallet.singularDTVPath"></span>
+                </label>
+              </td>
+              <td> SingularDTV </td>
+            </tr>
+
+            <tr>
+              <td>
+                <label class="radio">
                   <input aria-describedby="Path: TREZOR - TESTNET - {{HDWallet.trezorTestnetPath}}"
                          ng-change="onHDDPathChange()"
                          ng-model="HDWallet.dPath"

--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -24,7 +24,8 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
         trezorClassicPath: "m/44'/61'/0'/0",       // first address: m/44'/61'/0'/0/0
         trezorPath:        "m/44'/60'/0'/0",       // first address: m/44'/60'/0'/0/0
         hwUbqPath:         "m/44'/108'/0'/0",      // first address: m/44'/40'/0'/0/0
-        hwExpansePath:     "m/44'/40'/0'/0"        // first address: m/44'/40'/0'/0/0
+        hwExpansePath:     "m/44'/40'/0'/0",       // first address: m/44'/40'/0'/0/0
+        singularDTVPath:   "m/0'/0'/0'"            // first address: m/0'/0'/0'/0
     };
     $scope.HDWallet.dPath = $scope.HDWallet.defaultDPath;
     $scope.mnemonicModel = new Modal(document.getElementById('mnemonicModel'));

--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -398,6 +398,18 @@
               </label>
             </div>
 
+            <div class="col-sm-4">
+              <label class="radio small">
+                <input aria-describedby="Path: SingularDTV {{HDWallet.singularDTVPath}}"
+                       ng-change="onHDDPathChange()"
+                       ng-model="HDWallet.dPath"
+                       type="radio"
+                      value="{{HDWallet.singularDTVPath}}"/>
+                <span ng-bind="HDWallet.singularDTVPath"></span>
+                <p class="small">SingularDTV</p>
+              </label>
+            </div>
+
           </section>
 
           <section class="row">


### PR DESCRIPTION
SingularDTV used ConsenSys/eth-lightwallet's default derivation path of `m/0'/0'/0'` since spring of 2016, before `m/44'/60'/0'` getting a lot of traction. Many users have created SingularDTV lightwallets over the past 18 months, and it would help a lot if they could access their wallets directly from MEW without the need to enter the derivation path manually.