### PR TITLE
Update IMT token contract Address

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -444,7 +444,7 @@
 "decimal":0,
 "type":"default"
 },{
-"address":"0xED19698C0abdE8635413aE7AD7224DF6ee30bF22",
+"address":"0x22E5F62D0FA19974749faa194e3d3eF6d89c08d7",
 "symbol":"IMT",
 "decimal":0,
 "type":"default"


### PR DESCRIPTION
We change the token address due to small bug in contract code.

The old address was added to MyEtherWallet in this pull request https://github.com/kvhnuke/etherwallet/pull/826

We deploy the new contract and redistribute all token to token holders.