### PR TITLE
Added SALT ERC-20 token

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1083,4 +1083,9 @@
 "symbol":"REQ",
 "decimal":18,
 "type":"default"
+},{
+"address":"0x4156D3342D5c385a87D264F90653733592000581",
+"symbol":"SALT",
+"decimal":8,
+"type":"default"
 }]


### PR DESCRIPTION
SALT is an ERC-20 token distributed by [SALT Lending](https://saltlending.com/) that provides access to the SALT Lending platform.