### PR TITLE
Change ENJ crowdsale address to token address.

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -329,7 +329,7 @@
 "decimal":2,
 "type":"default"
 },{
-"address":"0x9b73D1779C41DcA36314fB7c4D3309838e20C4E7",
+"address":"0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
 "symbol":"ENJ",
 "decimal":18,
 "type":"default"


### PR DESCRIPTION
The address for the ENJ token was added incorrectly.

The user committed the crowdsale address: https://etherscan.io/address/0x9b73D1779C41DcA36314fB7c4D3309838e20C4E7

Instead of the token address: https://etherscan.io/token/0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c