### PR TITLE
Don't list tokens with invalid balances.

### DIFF
--- a/app/includes/sendTx-content.tpl
+++ b/app/includes/sendTx-content.tpl
@@ -22,7 +22,7 @@
         </a>
         <ul class="dropdown-menu dropdown-menu-right" ng-show="dropdownAmount && !tx.readOnly">
           <li><a ng-class="{true:'active'}[tx.sendMode=='ether']" ng-click="setSendMode('ether')">{{ajaxReq.type}}</a></li>
-          <li ng-repeat="token in wallet.tokenObjs track by $index" ng-show="token.balance!=0 && token.balance!='loading' || token.type!=='default' || tokenVisibility=='shown'">
+          <li ng-repeat="token in wallet.tokenObjs track by $index" ng-show="token.balance!=0 && token.balance!='loading' && token.balance.trim()!='Not a valid ERC-20 token' || token.type!=='default' || tokenVisibility=='shown'">
             <a ng-class="{true:'active'}[unitReadable == token.getSymbol()]" ng-click="setSendMode('token', $index, token.getSymbol())"> {{token.getSymbol()}} </a>
           </li>
 


### PR DESCRIPTION
I filed #1137 a little bit ago and this was the first thing that worked. I'm not sure if it's my lack of Angular understanding or what, but attempting to just do some sort of numeric check on the token balances really didn't work out for me.

Anyway, PR cleans up the list so that default tokens with invalid balances aren't populated in the Send ETH/Token dropdown list.