### PR TITLE
Added the ZAP token as a supported ETH token

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1155,6 +1155,11 @@
 "decimal":18,
 "type":"default"
 },{
+"address":"0x6781a0f84c7e9e846dcb84a9a5bd49333067b104",
+"symbol":"ZAP",
+"decimal": 18,
+"type":"default"
+},{
 "address":"0xE41d2489571d322189246DaFA5ebDe1F4699F498",
 "symbol":"ZRX",
 "decimal":18,


### PR DESCRIPTION
Added the ZAP Store Ethereum contract to the supported tokens list.
[Website](https://zap.store/)
To get in contact with us: hello@zapproject.org
Please also check us out on [GitHub](https://github.com/zapproject/)