### PR TITLE
Use globalFuncs.localStorage instead of localStorage at 2 places

### DIFF
--- a/app/scripts/globalFuncs.js
+++ b/app/scripts/globalFuncs.js
@@ -329,7 +329,7 @@ globalFuncs.saveTokenToLocal = function(localToken, callback) {
             network: globalFuncs.getDefaultTokensAndNetworkType().networkType
         });
 
-        localStorage.setItem("localTokens", JSON.stringify(storedTokens));
+        globalFuncs.localStorage.setItem("localTokens", JSON.stringify(storedTokens));
 
         callback({
           error: false

--- a/app/scripts/myetherwallet.js
+++ b/app/scripts/myetherwallet.js
@@ -65,7 +65,7 @@ Wallet.prototype.setTokens = function () {
 };
 
 function saveToLocalStorage(key, value) {
-  localStorage.setItem(key, JSON.stringify(value))
+  globalFuncs.localStorage.setItem(key, JSON.stringify(value))
 }
 
 function removeConflictingTokensFromLocalStorage(conflictLocalTokens, localTokens) {


### PR DESCRIPTION
This is important for me, because in my local installation, I have multiple copies of myetherwallet at file:// locations and each of them is overriding globalFuncs.localStorage to have a separate key prefix.  This way I can have multiple installations all having a separate configuration (e.g. for ETC/ETH or for different custom tokens, etc.).

So I patch the source code at globalFuncs.localStorage.setItem and globalFuncs.localStorage.getItem.  And therefore it's important for me that all localStorage access goes through these central functions.  This is the case for almost everything in MEW, except for these 2 occurrences that I fix in this PR.