### PR TITLE
Update BET (DAO.Casino) contract address

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -119,7 +119,7 @@
 "decimal":0,
 "type":"default"
 },{
-"address":"0x725803315519de78D232265A8f1040f054e70B98",
+"address":"0x8aA33A7899FCC8eA5fBe6A608A109c3893A1B8b2",
 "symbol":"BET",
 "decimal":18,
 "type":"default"


### PR DESCRIPTION
Old address was the crowdsale address, not the actual token address. This results in the BET token not loading properly in MEW.