### PR TITLE
Correction in decimals for Aeron (ARN) token

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -71,7 +71,7 @@
 },{
 "address":"0xBA5F11b16B155792Cf3B2E6880E8706859A8AEB6",
 "symbol":"ARN",
-"decimal":18,
+"decimal":8,
 "type":"default"
 },{
 "address":"0xfec0cF7fE078a500abf15F1284958F22049c2C7e",


### PR DESCRIPTION
The correct value for decimals is updated to match the smart contract