### PR TITLE
Updated STAR Token on defaults

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1169,7 +1169,7 @@
 "decimal":18,
 "type":"default"
 },{
-"address":"0xc301b935d0fd1f5d0b6d68491deca39d44e2da6e",
+"address":"0xF70a642bD387F94380fFb90451C2c81d4Eb82CBc",
 "symbol":"STAR",
 "decimal":18,
 "type":"default"


### PR DESCRIPTION
Updated STAR token to correct address, and it doesn't affect to market and you wallet functionalities, because the crowdsale is not finished yet, and no tokens can be transferable now