### PR TITLE
Change color theme to green when switch to ETC

### DIFF
--- a/app/includes/header.tpl
+++ b/app/includes/header.tpl
@@ -91,7 +91,7 @@
   </div>
 }
 
-<section class="bg-gradient header-branding">
+<section id="header-branding" class="bg-gradient header-branding">
   <section class="container">
     @@if (site === 'mew' ) {
       <a class="brand" href="/" aria-label="Go to homepage">

--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -61,6 +61,11 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
 
     var networkHasChanged = false;
     $scope.changeNode = function(key) {
+        if (key.startsWith("etc")) {
+            var headerBranding = angular.element(document.querySelector("#header-branding"));
+            headerBranding.removeClass("bg-gradient");
+            headerBranding.addClass("bg-gradient-green");
+        }
         var newNode = makeNewNode(key);
         if (!$scope.curNode) {
           networkHasChanged = false;

--- a/app/styles/etherwallet-utilities.less
+++ b/app/styles/etherwallet-utilities.less
@@ -10,6 +10,10 @@
   background: @ether-navy;
   background: linear-gradient(149deg,#132a45,#143a56,#21a4ce,#19b4ad);
 }
+.bg-gradient-green {
+  background: @ether-navy;
+  background: linear-gradient(45deg,#011c03,#0f8b19,#19d138,#3cd948);
+}
 .bg-gray-lighter    {  background-color: @gray-lighter;  }
 .bg-blue        {  background-color: @ether-blue;  }
 .bg-white       {  background-color: #fff;         }


### PR DESCRIPTION
Users will sometimes forget to distinguish which Ethereum chain they are using, and will accidentally send their crypto assets through a wrong chain, let's say someone thought he created an ETH wallet and then send his ETC to that wallet address.

So I think a proper way to address this is to change color theme for different Ethereum chains, right now if a user selects an ETC pool, it will change the header branding to ETC's green color as following, otherwise, it will remain the blue theme for ETH.

![image](https://user-images.githubusercontent.com/6234553/33436296-9bfeb0d0-d61f-11e7-8647-4b00e2e18280.png)
