### PR TITLE
updated BTE default token contract address

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -219,9 +219,9 @@
 "decimal":8,
 "type":"default"
 },{
-"address":"0x73dd069c299a5d691e9836243bcaec9c8c1d8734",
+"address":"0x6733d909e10ddedb8d6181b213de32a30ceac7ed",
 "symbol":"BTE",
-"decimal":8,
+"decimal":18,
 "type":"default"
 },{
 "address":"0xfad572db566e5234ac9fc3d570c4edc0050eaa92",


### PR DESCRIPTION
from bitcoineum (BTE) contract address to BitSerial (BTE) contract address. BitSerial has twice as many transactions.