### PR TITLE
INS token added

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -693,6 +693,11 @@
 "symbol":"IND",
 "decimal":18,
 "type":"default"
+}, {
+"address":"0x5b2e4a700dfbc560061e957edec8f6eeeb74a320",
+"symbol":"INS",
+"decimal":10,
+"type":"default"
 },{
 "address":"0xa8006c4ca56f24d6836727d106349320db7fef82",
 "symbol":"INXT",


### PR DESCRIPTION
INS token is the primary token of the INS ecosystem and its ongoing ICO: https://ins.world/#token_sale

INS tokens will be distributed after the end of the ICO

Contact email: info@ins.world
ENS: https://etherscan.io/address/instoken.eth

Should not be confused with INSP