### PR TITLE
Rename VEN to VET

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1540,7 +1540,7 @@
 "type":"default"
 },{
 "address": "0xD850942eF8811f2A866692A623011bDE52a462C1",
-"symbol": "VEN",
+"symbol": "VET",
 "decimal": 18,
 "type": "default"
 },{


### PR DESCRIPTION
We are currently doing a rebranding, renaming VEN to VET. Check [this post](https://medium.com/@vechainofficial/vechain-apotheosis-the-beginning-d9f0fdbdc910) for official announcement

Official Site URL: https://tokensale.vechain.com/en/
github: https://github.com/vechain/
whitepaper: https://cdn.vechain.com/vechain_ico_ideas_of_development_en.pdf
token tracker: https://etherscan.io/token/0xd850942ef8811f2a866692a623011bde52a462c1
Official Support Email Address: support@vechain.com

we are working on the modification on our website and other relevant official documents. Beside, exchanges are notified too. Shall you have any questions, please feel free to comment.