### PR TITLE
Adding EDU token

### DIFF
--- a/app/scripts/customGas.js
+++ b/app/scripts/customGas.js
@@ -258,4 +258,10 @@ to:         '0x92685E93956537c25Bb75D5d47fca4266dd628B8',
 gasLimit:   200000,
 data:       '',
 msg:        'Bitlle Token. Official website https://bitlle.com'
+},{
+// EDU Token Sale (LiveEdu.tv)
+to:         '0x2097175d0abb8258f2468E3487F8db776E29D076',
+gasLimit:   200000,
+data:       '',
+msg:        'LiveEdu EDU token sale. Official website: https://tokensale.liveedu.tv/'
 }]

--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -499,6 +499,11 @@
 "decimal":18,
 "type":"default"
 },{
+"address":"0x5b26C5D0772E5bbaC8b3182AE9a13f9BB2D03765",
+"symbol":"EDU",
+"decimal":8,
+"type":"default"
+},{
 "address":"0xf9F0FC7167c311Dd2F1e21E9204F87EBA9012fB2",
 "symbol":"EHT",
 "decimal":8,


### PR DESCRIPTION
Hi!

We (LiveEdu.tv team) are running an ICO and would like to add our upcoming EDU token to the default tokens list.

ICO website: https://tokensale.liveedu.tv (of course, included in the commit message)
Token contract: https://etherscan.io/address/0x5b26c5d0772e5bbac8b3182ae9a13f9bb2d03765
Sale contract: https://etherscan.io/address/0x2097175d0abb8258f2468E3487F8db776E29D076

Oh, we have an old GitHub account name, @LivecodingTVOfficial - haven't changed that since we were Livecoding.tv, as there are links to our repos. Still, it's us ;)

Thanks!