### PR TITLE
set node from url query

### DIFF
--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -103,7 +103,12 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
             }
         });
         networkHasChanged && window.setTimeout(function() {
-            window.location = window.location.href.replace(window.location.search, '');
+            if (window.location.search.length > 0) {
+                window.location = window.location.href.replace(window.location.search, '');
+            } else {
+                window.location.reload();
+            }
+            
         }, 250)
     }
     $scope.checkNodeUrl = function(nodeUrl) {

--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -87,7 +87,7 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
         for (var attrname in $scope.curNode)
             if (attrname != 'name' && attrname != 'tokenList' && attrname != 'lib')
                 ajaxReq[attrname] = $scope.curNode[attrname];
-        globalFuncs.localStorage.setItem('curNode', JSON.stringify({
+            globalFuncs.localStorage.setItem('curNode', JSON.stringify({
             key: key
         }));
         if (nodes.ensNodeTypes.indexOf($scope.curNode.type) == -1) $scope.tabNames.ens.cx = $scope.tabNames.ens.mew = false;
@@ -102,7 +102,9 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
                 $scope.notifier.info( globalFuncs.successMsgs[5] + '— Now, check the URL: <strong>' + window.location.href + '.</strong> <br /> Network: <strong>' + $scope.nodeType + ' </strong> provided by <strong>' + $scope.nodeService + '.</strong>', 5000)
             }
         });
-        networkHasChanged && window.setTimeout(function() {location.reload() }, 250)
+        networkHasChanged && window.setTimeout(function() {
+            window.location = window.location.href.replace(window.location.search, '');
+        }, 250)
     }
     $scope.checkNodeUrl = function(nodeUrl) {
         return $scope.Validator.isValidURL(nodeUrl);
@@ -112,7 +114,17 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
         if (node === JSON.stringify({"key":"eth_metamask"})) {
           node = JSON.stringify({"key":"eth_infura"})
         }
-       if (node == null) {
+
+        var requestedCoin = globalFuncs.urlGet('coin');
+        if (requestedCoin) {
+            if (requestedCoin === 'etc') {
+                node = JSON.stringify({"key":"etc_epool"});
+            } else if(requestedCoin === 'eth') {
+                node = JSON.stringify({"key":"eth_mew"});
+            }
+        }
+        
+        if (node == null) {
             $scope.changeNode($scope.defaultNodeKey);
         } else {
             node = JSON.parse(node);

--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -120,13 +120,9 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
           node = JSON.stringify({"key":"eth_infura"})
         }
 
-        var requestedCoin = globalFuncs.urlGet('coin');
-        if (requestedCoin) {
-            if (requestedCoin === 'etc') {
-                node = JSON.stringify({"key":"etc_epool"});
-            } else if(requestedCoin === 'eth') {
-                node = JSON.stringify({"key":"eth_mew"});
-            }
+        var requestedNetwork = globalFuncs.urlGet('network');
+        if (requestedNetwork && nodes.nodeList.hasOwnProperty(requestedNetwork)) {
+            node = JSON.stringify({ "key": requestedNetwork });
         }
         
         if (node == null) {


### PR DESCRIPTION
Hi,
We would like to add a new feature which allows MEW to decide which node should be used directly from url param like "?coin=etc" or "?coin=eth".
We get complains from our customers that they want to go directly to MEW Ethereum Classic wallet from TREZOR wallet, but unfortunately MEW node will be set according to MEW local storage where defaultNodeKey is set to "etc_epool".

Please let us know if you are OK with this feature (maybe you want to set different name for this parameter) and we will implement this redirection from TREZOR wallet.