### PR TITLE
ethTokens.json Removed invalid tokens

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1384,11 +1384,6 @@
 "decimal":18,
 "type":"default"
 },{
-"address":"0x2a3Aa9ECA41E720Ed46B5A70D6C37EfA47f768Ac",
-"symbol":"RCT",
-"decimal":18,
-"type":"default"
-},{
 "address":"0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
 "symbol":"RDN",
 "decimal":18,
@@ -1451,11 +1446,6 @@
 },{
 "address":"0xb4efd85c19999d84251304bda99e90b92300bd93",
 "symbol":"RPL",
-"decimal":18,
-"type":"default"
-},{
-"address":"0x41f615e24fabd2b097a320e9e6c1f448cb40521c",
-"symbol":"RVL",
 "decimal":18,
 "type":"default"
 },{


### PR DESCRIPTION
Both RCT and RVL added [here](https://github.com/kvhnuke/etherwallet/commit/c171be0df6a998bd47141d944ca6697f3e954a26) are standard wallet adresses and not a contract. These can't be ERC20 tokens.
[RCT](https://etherscan.io/address/0x2a3Aa9ECA41E720Ed46B5A70D6C37EfA47f768Ac)
[RVL](https://etherscan.io/address/0x41f615e24fabd2b097a320e9e6c1f448cb40521c)