### PR TITLE
IDH token added

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -989,6 +989,11 @@
 "decimal":0,
 "type":"default"
 },{
+"address":"0x5136c98a80811c3f46bdda8b5c4555cfd9f812f0",
+"symbol":"IDH",
+"decimal":6,
+"type":"default"
+},{
 "address":"0x7654915a1b82d6d2d0afc37c52af556ea8983c7e",
 "symbol":"IFT",
 "decimal":18,


### PR DESCRIPTION
Token indaHash Coin: https://ethplorer.io/address/0x5136c98a80811c3f46bdda8b5c4555cfd9f812f0
IDH token is the primary token of the indaHash  and its ongoing ICO: [https://indahash.com/ico](https://indahash.com/ico)

IndaHash ICO is over and IDH token is listing on:
- [Tidex](https://tidex.com/exchange/idh/eth)
- [HitBTC](https://hitbtc.com/IDH-to-BTC)

