### PR TITLE
Changed EDU token symbol to LEDU

### DIFF
--- a/app/scripts/customGas.js
+++ b/app/scripts/customGas.js
@@ -248,11 +248,11 @@ gasLimit:   200000,
 data:       '',
 msg:        'Bitlle Token. Official website https://bitlle.com'
 },{
-// EDU Token Sale (LiveEdu.tv)
+// LEDU Token Sale (LiveEdu.tv)
 to:         '0x2097175d0abb8258f2468E3487F8db776E29D076',
 gasLimit:   200000,
 data:       '',
-msg:        'LiveEdu EDU token sale. Official website: https://tokensale.liveedu.tv/'
+msg:        'LiveEdu LEDU token sale. Official website: https://tokensale.liveedu.tv/'
 },{
 // HEdpAY (Hdp.ф) Sale (hedpay.com)
 to:         '0x4F8B6cA78711207E1B281DB63e8d6EAA1ce2F63E',

--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -931,7 +931,7 @@
   },
   {
     "address": "0x5b26C5D0772E5bbaC8b3182AE9a13f9BB2D03765",
-    "symbol": "EDU",
+    "symbol": "LEDU",
     "decimal": 8,
     "type": "default"
   },


### PR DESCRIPTION
Hi!

We (LiveEdu.tv team) have changed token symbol from EDU to LEDU. Please accept our change to the default tokens list.

Official website: http://tokensale.liveedu.tv
Support email: tokensale@liveedu.tv
Telegram: https://t.me/liveeduico