### PR TITLE
added timestamp parameter to TrezorConnect popup.html to avoid caching

### DIFF
--- a/app/scripts/staticJS/trezorConnect.js
+++ b/app/scripts/staticJS/trezorConnect.js
@@ -42,7 +42,7 @@ if (window.location.hostname === 'localhost' && !window.TREZOR_POPUP_ORIGIN) {
     //POPUP_ORIGIN = window.location.origin;
     //POPUP_PATH = POPUP_ORIGIN;
 }
-var POPUP_URL = window.TREZOR_POPUP_URL || POPUP_PATH + '/popup/popup.html';
+var POPUP_URL = window.TREZOR_POPUP_URL || POPUP_PATH + '/popup/popup.html?v=' + new Date().getTime();
 
 var POPUP_INIT_TIMEOUT = 15000;
 


### PR DESCRIPTION
We get complains about problems with TrezorConnect and most of them are caused by cached html in popup. Could you add this patch to avoid this behaviour?
You can find this commit in connect repository:
https://github.com/trezor/connect/commit/e6214d63d2ab7b9827d11b6e3f5fe27d8b5e2081