### PR TITLE
Renamed decimals label to decimal and reformatted symbol field for address 0x386Faa4703a34a7Fdb19Bec2e14Fd427C9638416

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1021,8 +1021,8 @@
 	},
 	{
 		"address": "0x386Faa4703a34a7Fdb19Bec2e14Fd427C9638416",
-		"symbol": "DoBETacceptBET(DCA)",
-		"decimals": 18,
+		"symbol": "DCA (doBETacceptBET)",
+		"decimal": 18,
 		"type": "default"
 	},
 	{


### PR DESCRIPTION
Every other currency has a field named "decimal", this one had "decimals" instead.  Also, the other currencies with symbol collisions had format "XYZ (Long name)" so I reformatted that at the same time, and changed the long name to doBETacceptBET to match the project name, e.g.. @doBETacceptBET on Twitter.
