### PR TITLE
Add Cardstack (CARD) token to the default token list

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -635,6 +635,12 @@
 		"decimal": 8,
 		"type": "default"
 	},
+  {
+		"address": "0x1ed2B1eaEd8e968bc36EB90a914660A71827A5E9",
+		"symbol": "CARD",
+		"decimal": 0,
+		"type": "default"
+  },
 	{
 		"address": "0xbf18f246b9301f231e9561b35a3879769bb46375",
 		"symbol": "CARE",


### PR DESCRIPTION
Hello,
We'd like to add the Cardstack token, CARD, to My Ether Wallet.

Our official website is https://cardstack.com
Our telegram group is at: https://telegram.me/cardstack
Our Medium is: https://medium.com/cardstack
Our GitHub: is: https://github.com/cardstack
Our twitter is: @cardstack
Our support email is: support@cardstack.com

Thanks!