### PR TITLE
Warn when MetaMask is locked

### DIFF
--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -391,6 +391,10 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
     $scope.scanMetamask = function() {
         window.web3.eth.getAccounts(function (err, accounts) {
           if (err) $scope.notifier.danger(err + '. Are you sure you are on a secure (SSL / HTTPS) connection?')
+          if (!accounts.length) {
+            $scope.notifier.danger('Could not read your accounts from MetaMask. Try unlocking it.');
+            return;
+          }
           var address = accounts[0]
           var addressBuffer = Buffer.from(address.slice(2), 'hex');
           var wallet = new Web3Wallet(addressBuffer);


### PR DESCRIPTION
When attempting to access a locked MetaMask wallet. 

Before:

```
Uncaught TypeError: Cannot read property 'slice' of undefined
  ...
```

(with no user feedback)

After:

![screen shot 2018-06-01 at 11 25 19 am](https://user-images.githubusercontent.com/117682/40856971-80fb4d30-658e-11e8-98a0-43092875b6c1.png)
