### PR TITLE
upgraded Cardstack CARD token to new address

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -672,9 +672,9 @@
 		"type": "default"
 	},
 	{
-		"address": "0x1ed2B1eaEd8e968bc36EB90a914660A71827A5E9",
+		"address": "0xB07ec2c28834B889b1CE527Ca0F19364cD38935c",
 		"symbol": "CARD",
-		"decimal": 0,
+		"decimal": 18,
 		"type": "default"
 	},
 	{


### PR DESCRIPTION
Hello, we've upgraded our token contract to a new address. Our new token address is reflected by the ENS entry `cardstack.eth` which now resolves to `0xB07ec2c28834B889b1CE527Ca0F19364cD38935c`

Additionally, we have blogged about this upgrade for our token holders:
https://medium.com/cardstack/the-first-cardstack-smart-contract-upgrade-f9f07cf0955a