### PR TITLE
fixed collapse-button style

### DIFF
--- a/app/styles/etherwallet-custom.less
+++ b/app/styles/etherwallet-custom.less
@@ -308,10 +308,17 @@ input[type="password"]+.eye {
     float: left;
     font-weight: 500;
     user-select: none;
-    padding: .25rem;
-    margin: .25rem -30px;
+    padding: 0;
+    margin: 5px -30px;
     font-size: 1.6rem;
-    line-height: 1.6;
+    line-height: 0.95;
+    display: inline-block;
+    width: 25px;
+    height: 25px;
+    text-align: center;
+    border: 1px solid #ddd;
+    color: #c3c3c3;
+    border-radius: 5px;
   }
 }
 
@@ -865,6 +872,12 @@ header.EOSC {
   .contest-container {
     ol {
       padding: 0 5em !important;
+    }
+  }
+
+  .collapse-container {
+    .collapse-button {
+      margin-left: -100px;
     }
   }
 }


### PR DESCRIPTION
fixed weird css style of the collapse-button.

- [x] make the collapse-button more button like.
- [x] hide collapse-button conditionally for mobile layout

before
![image](https://user-images.githubusercontent.com/32324335/42073367-344671bc-7ba1-11e8-8134-e32dfd3122ee.png)

after
![image](https://user-images.githubusercontent.com/32324335/42073371-3c1278aa-7ba1-11e8-9b28-546bcf6c55ec.png)
