### PR TITLE
fixed misc css & layout

### DIFF
--- a/app/includes/header.tpl
+++ b/app/includes/header.tpl
@@ -112,7 +112,7 @@
     <span class="hidden-xs">3.21.15</span>
 
     <span class="dropdown dropdown-lang" ng-cloak>
-      <a tabindex="0"  aria-haspopup="true" aria-expanded="false" aria-label="change language. current language {{curLang}}" class="dropdown-toggle  btn btn-white" ng-click="dropdown = !dropdown">{{curLang}}<i class="caret"></i></a>
+      <a tabindex="0"  aria-haspopup="true" aria-expanded="false" aria-label="change language. current language {{curLang}}" class="dropdown-toggle" ng-click="dropdown = !dropdown">{{curLang}}<i class="caret"></i></a>
       <ul class="dropdown-menu" ng-show="dropdown">
         <li><a ng-class="{true:'active'}[curLang=='Català']"          ng-click="changeLanguage('ca','Català'         )"> Català          </a></li>
         <li><a ng-class="{true:'active'}[curLang=='Deutsch']"         ng-click="changeLanguage('de','Deutsch'        )"> Deutsch         </a></li>
@@ -172,14 +172,6 @@
              rel="noopener noreferrer"></a>
         </div>
       </ul>
-      <p class="dropdown-gas__msg"
-         ng-show="gasPriceMsg"
-         ng-hide="ajaxReq.type!='ETH'">
-        The network is really full right now. Check
-        <a href="https://ethgasstation.info/"
-           target="_blank" rel="noopener noreferrer">Eth Gas Station</a>
-        for gas price to use.
-      </p>
     </span>
 
     <!-- Warning: The separators you see on the frontend are in styles/etherwallet-custom.less. If you add / change a node, you have to adjust these. Ping tayvano if you're not a CSS wizard -->
@@ -212,6 +204,14 @@
 
     </div>
   </section>
+  <p class="dropdown-gas__msg"
+     ng-show="gasPriceMsg"
+     ng-hide="ajaxReq.type!='ETH'">
+    The network is really full right now. Check
+    <a href="https://ethgasstation.info/"
+       target="_blank" rel="noopener noreferrer">Eth Gas Station</a>
+    for gas price to use.
+  </p>
 </section>
 
 <nav role="navigation" aria-label="main navigation" class="container nav-container overflowing">

--- a/app/styles/etherwallet-custom.less
+++ b/app/styles/etherwallet-custom.less
@@ -513,14 +513,17 @@ label small {
 .dropdown-gas__msg {
   font-size: 12px;
   font-weight:300;
-  left: -100%;
-  margin: 0;
-  position: absolute;
-  right: -100%;
+  margin: -10px auto 3px auto;
+  max-width: 113rem;
+  padding: 0 5rem;
+  text-align: right;
   white-space:normal;
+  @media screen and (max-width: 80rem) {
+    padding: 0 3%;
+  }
   @media screen and (max-width: 900px) {
-    left: -25%;
-    right: 0;
+    margin-top: 0;
+    padding: 0 1%;
   }
 
 }

--- a/app/styles/etherwallet-nav.less
+++ b/app/styles/etherwallet-nav.less
@@ -2,7 +2,7 @@
 .header-branding {
   color: white;
   padding: 0;
-  @media screen and (max-width: 900px) {
+  @media screen and (max-width: 960px) {
     text-align: center;
   }
   .container {
@@ -15,11 +15,12 @@
     }
   }
   .brand {
+    float: left;
+    @media screen and (max-width: 900px) {
+      float: none;
+    }
     img {
       padding: @space-xs 0;
-      @media screen and (max-width: 900px) {
-        max-width: 10rem;
-      }
     }
   }
   .tagline {
@@ -82,14 +83,8 @@
   }
   .dropdown-gas {
     display: inline-block;
-    @media screen and (max-width: 900px) {
-      margin-bottom: 1.8rem;
-    }
-    .dropdown-toggle {
-      min-width: 200px;
-    }
     .dropdown-menu{
-      min-width: 100%;
+      min-width: 200px;
       padding: .5rem;
       margin: 0;
       left: 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32324335/42104153-86211ec8-7c06-11e8-948f-4ff14ae988cf.png)

- styling language selection box optional (or less likely usable),
- and make two selection boxes (gas, chain) more likely usable
- fixed layout to show `gasPriceMessage` more consistent
- fixed caret and the logo css to show them consistently.