### PR TITLE
Enable Ledger Hardware Wallet support for EtherGem (EGEM)

### DIFF
--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -74,6 +74,9 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
                 case nodes.nodeTypes.ETHO:
                     $scope.HDWallet.dPath = $scope.HDWallet.hwEther1Path;
                     break;
+                case nodes.nodeTypes.EGEM:
+                    $scope.HDWallet.dPath = $scope.HDWallet.hwEtherGemPath;
+                    break;
                 default:
                     $scope.HDWallet.dPath = $scope.HDWallet.ledgerPath;
             }

--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -35,7 +35,7 @@
     <!-- Ledger -->
     <label aria-flowto="aria3"
            class="radio"
-           ng-show="ajaxReq.type=='ETH'||ajaxReq.type=='ETC'||ajaxReq.type=='ROPSTEN ETH'||ajaxReq.type=='RINKEBY ETH'||ajaxReq.type=='KOVAN ETH'||ajaxReq.type=='EXP'||ajaxReq.type=='UBQ'||ajaxReq.type=='POA'||ajaxReq.type=='TOMO'||ajaxReq.type=='ESN'||ajaxReq.type=='AKROMA'||ajaxReq.type=='PIRL'||ajaxReq.type=='ETHO'">
+           ng-show="ajaxReq.type=='ETH'||ajaxReq.type=='ETC'||ajaxReq.type=='ROPSTEN ETH'||ajaxReq.type=='RINKEBY ETH'||ajaxReq.type=='KOVAN ETH'||ajaxReq.type=='EXP'||ajaxReq.type=='UBQ'||ajaxReq.type=='POA'||ajaxReq.type=='TOMO'||ajaxReq.type=='ESN'||ajaxReq.type=='AKROMA'||ajaxReq.type=='PIRL'||ajaxReq.type=='ETHO'||ajaxReq.type=='EGEM'">
       <input aria-flowto="aria3"
              type="radio"
              aria-label="Ledger Hardware Wallet"


### PR DESCRIPTION
EIP-155 is now properly working with EtherGem!! Tested personally on the Ledger Nano S

homepage : https://egem.io
block explorer : https://explorer.egem.io
network statistics : https://network.egem.io
slip0044 index : 1987
chainId : 1987

MyEtherWallet Full 32bit Chain ID support: (merged)
#1979

Ledger Nano S Full 32bit Chain ID support: (merged)
LedgerHQ/blue-app-eth@8260268
LedgerHQ/blue-app-eth@74c085c

Ledger Nano S EtherGem (EGEM) app: (merged)
LedgerHQ/blue-app-eth#28

EtherGem is on Ledger's official roadmap:
https://trello.com/c/lGIfDKq1/120-ethergem-support

cc: @TeamEGEM