### PR TITLE
Fix transaction history link text

### DIFF
--- a/app/scripts/directives/balanceDrtv.html
+++ b/app/scripts/directives/balanceDrtv.html
@@ -36,7 +36,7 @@
     <ul class="account-info">
       <li ng-show="ajaxReq.type != 'CUS'">
         <a href="{{ajaxReq.blockExplorerAddr.replace('[[address]]', wallet.getAddressString())}}" target="_blank" rel="noopener noreferrer">
-          {{ajaxReq.type}} ({{ajaxReq.blockExplorerTX.replace('/tx/[[txHash]]', '')}})
+          {{ajaxReq.type}} ({{ajaxReq.blockExplorerTX.match('://(.*?)/')[1]}})
         </a>
       </li>
       <li ng-show="ajaxReq.type == 'ETH'">
@@ -147,7 +147,7 @@
          href="{{ajaxReq.blockExplorerAddr.replace('[[address]]', wallet.getAddressString())}}"
          target="_blank"
          rel="noopener noreferrer">
-          {{ajaxReq.blockExplorerTX.replace('/tx/[[txHash]]', '')}}
+          {{ajaxReq.blockExplorerTX.match('://(.*?)/')[1]}}
       </a>
       <span ng-show="ajaxReq.type == 'ETH'"> or
         <a href="https://ethplorer.io/address/{{wallet.getAddressString()}}"


### PR DESCRIPTION
The current code expects each blockExplorerTX link to be of the form:
`some.server.tld/tx/[[txHash]]`
and fails to display correctly if the URLs are structured otherwise:

![image](https://user-images.githubusercontent.com/1062488/44384463-4020e400-a4ea-11e8-9064-4c1135b7a4f7.png)
![image](https://user-images.githubusercontent.com/1062488/44384561-9726b900-a4ea-11e8-8417-937afde0e7d9.png)

Instead of depending on this static text replacement, grab the text that we actually want:

![image](https://user-images.githubusercontent.com/1062488/44384491-5cbd1c00-a4ea-11e8-8c1c-99901a81e488.png)
![image](https://user-images.githubusercontent.com/1062488/44384607-ba516880-a4ea-11e8-935c-edb3a100676b.png)
![image](https://user-images.githubusercontent.com/1062488/44384701-08ff0280-a4eb-11e8-95b6-7df6213b4169.png)
![image](https://user-images.githubusercontent.com/1062488/44384714-14eac480-a4eb-11e8-836f-348976c957b3.png)

cc @detroitpro 
cc @masterdubs