### PR TITLE
BUG FIX: Fix missing break after bad merge conflict resolution

### DIFF
--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -80,6 +80,7 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
                     break;
                 case nodes.nodeTypes.ATH:
                     $scope.HDWallet.dPath = $scope.HDWallet.hwAtheiosPath;
+                    break;
                 case nodes.nodeTypes.EGEM:
                     $scope.HDWallet.dPath = $scope.HDWallet.hwEtherGemPath;
                     break;


### PR DESCRIPTION
The `break;` statement got left out of the ATH case after merge conflict resolution.   Can we merge this fix before release?  O:-)

cc: @gamalielhere 