### PR TITLE
Add Ledger support for Musicoin

### DIFF
--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -84,6 +84,9 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
                 case nodes.nodeTypes.EGEM:
                     $scope.HDWallet.dPath = $scope.HDWallet.hwEtherGemPath;
                     break;
+                case nodes.nodeTypes.MUSIC:
+                    $scope.HDWallet.dPath = $scope.HDWallet.hwMusicoinPath;
+                    break;
                 default:
                     $scope.HDWallet.dPath = $scope.HDWallet.ledgerPath;
             }

--- a/app/scripts/controllers/decryptWalletCtrl.js
+++ b/app/scripts/controllers/decryptWalletCtrl.js
@@ -140,6 +140,12 @@ var decryptWalletCtrl = function($scope, $sce, walletService) {
                 case nodes.nodeTypes.ESN:
                     $scope.HDWallet.dPath = $scope.HDWallet.hwESNetworkPath;
                     break;
+                case nodes.nodeTypes.PIRL:
+                    $scope.HDWallet.dPath = $scope.HDWallet.hwPirlPath;
+                    break;
+                case nodes.nodeTypes.ETHO:
+                    $scope.HDWallet.dPath = $scope.HDWallet.hwEther1Path;
+                    break;
                 case nodes.nodeTypes.ATH:
                     $scope.HDWallet.dPath = $scope.HDWallet.hwAtheiosPath;
                     break;

--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -47,7 +47,7 @@
     <!-- TREZOR -->
     <label class="radio"
            aria-flowto="aria4"
-           ng-show="ajaxReq.type=='ETH'||ajaxReq.type=='ETC'||ajaxReq.type=='ROPSTEN ETH'||ajaxReq.type=='RINKEBY ETH'||ajaxReq.type=='KOVAN ETH'||ajaxReq.type=='EXP'||ajaxReq.type=='UBQ'||ajaxReq.type=='POA'||ajaxReq.type=='TOMO'||ajaxReq.type=='ELLA'||ajaxReq.type=='EGEM'||ajaxReq.type=='CLO'||ajaxReq.type=='ETSC'||ajaxReq.type=='MUSIC'||ajaxReq.type=='GO'||ajaxReq.type=='EOSC'||ajaxReq.type=='AKROMA'||ajaxReq.type=='ESN'">
+           ng-show="ajaxReq.type=='ETH'||ajaxReq.type=='ETC'||ajaxReq.type=='ROPSTEN ETH'||ajaxReq.type=='RINKEBY ETH'||ajaxReq.type=='KOVAN ETH'||ajaxReq.type=='EXP'||ajaxReq.type=='UBQ'||ajaxReq.type=='POA'||ajaxReq.type=='TOMO'||ajaxReq.type=='ELLA'||ajaxReq.type=='EGEM'||ajaxReq.type=='CLO'||ajaxReq.type=='ETSC'||ajaxReq.type=='MUSIC'||ajaxReq.type=='GO'||ajaxReq.type=='EOSC'||ajaxReq.type=='AKROMA'||ajaxReq.type=='ESN'||ajaxReq.type=='PIRL'||ajaxReq.type=='ETHO'||ajaxReq.type=='ATH'">
       <input aria-flowto="aria4"
              type="radio"
              aria-label="Trezor Hardware Wallet"

--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -35,7 +35,7 @@
     <!-- Ledger -->
     <label aria-flowto="aria3"
            class="radio"
-           ng-show="ajaxReq.type=='ETH'||ajaxReq.type=='ETC'||ajaxReq.type=='ROPSTEN ETH'||ajaxReq.type=='RINKEBY ETH'||ajaxReq.type=='KOVAN ETH'||ajaxReq.type=='EXP'||ajaxReq.type=='UBQ'||ajaxReq.type=='POA'||ajaxReq.type=='TOMO'||ajaxReq.type=='ESN'||ajaxReq.type=='AKROMA'||ajaxReq.type=='PIRL'||ajaxReq.type=='ETHO'||ajaxReq.type=='EGEM'||ajaxReq.type=='CLO'||ajaxReq.type=='ATH'">
+           ng-show="ajaxReq.type=='ETH'||ajaxReq.type=='ETC'||ajaxReq.type=='ROPSTEN ETH'||ajaxReq.type=='RINKEBY ETH'||ajaxReq.type=='KOVAN ETH'||ajaxReq.type=='EXP'||ajaxReq.type=='UBQ'||ajaxReq.type=='POA'||ajaxReq.type=='TOMO'||ajaxReq.type=='ESN'||ajaxReq.type=='AKROMA'||ajaxReq.type=='PIRL'||ajaxReq.type=='ETHO'||ajaxReq.type=='EGEM'||ajaxReq.type=='CLO'||ajaxReq.type=='ATH'||ajaxReq.type=='MUSIC'">
       <input aria-flowto="aria3"
              type="radio"
              aria-label="Ledger Hardware Wallet"


### PR DESCRIPTION
EIP-155 is now properly working with Musicoin!! Tested personally on the Ledger Nano S

    homepage           : https://musicoin.org
    block explorer     : https://explorer.musicoin.org
    slip0044 index     : 184
    chainId            : 7762959

Musicoin has been unable to work with ledger hardware wallets until the following changes were applied:
https://github.com/LedgerHQ/blue-app-eth/commit/8260268b0214810872dabd154b476f5bb859aac0
https://github.com/LedgerHQ/blue-app-eth/commit/74c085ca2d032179fcf205cda1dee38c92877933

The Musicoin network has had EIP-155 Replay attack protection enabled on their network ever since the following PR got merged in February:
https://github.com/Musicoin/go-musicoin/pull/62

Musicoin is on LedgerHQ official roadmap:
https://trello.com/c/a3YFOxx1/114-musicoin-support

LedgerHQ official Musicoin app support: (merged)
https://github.com/LedgerHQ/ledger-app-eth/pull/20

Also included in this pull request, as per @gamalielhere 's request:
* Enable Trezor support for Pirl, Ether-1 and AtheiosChain

Pirl, Ether-1 and Atheios are now supported in TREZOR ONE firmware version 1.6.3
https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d