### PR TITLE
update CARD token address

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -720,7 +720,7 @@
     "type": "default"
   },
   {
-    "address": "0xB07ec2c28834B889b1CE527Ca0F19364cD38935c",
+    "address": "0x954b890704693af242613edef1b603825afcd708",
     "symbol": "CARD",
     "decimal": 18,
     "type": "default"


### PR DESCRIPTION
We have updated the CARD token address. The new address is `0x954b890704693af242613edEf1B603825afcD708` which is the address the ENS `cardstack.eth` now resolves to. Additionally, we have blogged about our address change here: https://cardstack.com/zos-upgrade