### PR TITLE
Fix Callisto 'blockExplorerTX', 'blockExplorerAddr' and 'service' text

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -316,8 +316,8 @@ nodes.nodeList = {
 	},
 	clo: {
 		name: "CLO",
-		blockExplorerTX: "https://cloexplorer.org/tx/[[txHash]]",
-		blockExplorerAddr: "https://cloexplorer.org/addr/[[address]]",
+		blockExplorerTX: "https://explorer.callisto.network/tx/[[txHash]]",
+		blockExplorerAddr: "https://explorer.callisto.network/account/[[address]]",
 		type: nodes.nodeTypes.CLO,
 		eip155: true,
 		chainId: 820,

--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -323,7 +323,7 @@ nodes.nodeList = {
 		chainId: 820,
 		tokenList: require("./tokens/cloTokens.json"),
 		abiList: require("./abiDefinitions/cloAbi.json"),
-		service: "Callisto.network",
+		service: "0xinfra.com",
 		lib: new nodes.customNode("https://clo-geth.0xinfra.com/", "")
 	},
 	music: {


### PR DESCRIPTION
* cloexplorer.org doesn't seem to work.  Update the `blockExplorerTX` & `blockExplorerAddr` fields to use https://explorer.callisto.network
* while we're here, set CLO network service text to "0xinfra.com" to reflect the actual rpc server in use

cc: @yograterol 