### PR TITLE
UBQ: update ubiqscan tx/address links

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -238,8 +238,8 @@ nodes.nodeList = {
 	},
 	ubq: {
 		name: "UBQ",
-		blockExplorerTX: "https://ubiqscan.io/en/tx/[[txHash]]",
-		blockExplorerAddr: "https://ubiqscan.io/en/address/[[address]]",
+		blockExplorerTX: "https://ubiqscan.io/tx/[[txHash]]",
+		blockExplorerAddr: "https://ubiqscan.io/address/[[address]]",
 		type: nodes.nodeTypes.UBQ,
 		eip155: true,
 		chainId: 8,


### PR DESCRIPTION
Ubiqscan was recently updated to a new codebase, the urls no longer contain a locale. This PR fixes the explorer links when UBQ network is selected.