### PR TITLE
Hardcoded link to etherscan in TX Status page fixed

### DIFF
--- a/app/includes/txStatus.tpl
+++ b/app/includes/txStatus.tpl
@@ -79,7 +79,7 @@
               TX Hash
             </td>
             <td>
-              <a href="https://etherscan.io/tx/{{ txInfo.hash }}" target="_blank" rel="noopener noreferrer">
+              <a href="{{ txInfo.txExplorerUrl }}" target="_blank" rel="noopener noreferrer">
                 {{ txInfo.hash }}
               </a>
             </td>
@@ -89,7 +89,7 @@
               From Address
             </td>
             <td>
-              <a href="https://etherscan.io/address/{{ txInfo.from }}" target="_blank" rel="noopener noreferrer">
+              <a href="{{ txInfo.fromExplorerUrl }}" target="_blank" rel="noopener noreferrer">
                 {{ txInfo.from }}
               </a>
             </td>
@@ -99,7 +99,7 @@
               To Address
             </td>
             <td>
-              <a href="https://etherscan.io/address/{{ txInfo.to }}" target="_blank" rel="noopener noreferrer">
+              <a href="{{ txInfo.toExplorerUrl }}" target="_blank" rel="noopener noreferrer">
                 {{ txInfo.to }}
               </a>
             </td>

--- a/app/scripts/controllers/txStatusCtrl.js
+++ b/app/scripts/controllers/txStatusCtrl.js
@@ -19,7 +19,10 @@ var txStatusCtrl = function($scope) {
         gasLimit: '',
         gasPrice: '',
         data: '',
-        nonce: ''
+        nonce: '',
+        txExplorerUrl: '',
+        fromExplorerUrl: '',
+        toExplorerUrl: ''
     }
 
     var applyScope = function() {
@@ -36,6 +39,8 @@ var txStatusCtrl = function($scope) {
         if (tx) {
             console.log('txToObject')
             console.log(tx)
+            var curNode = JSON.parse(globalFuncs.localStorage.getItem('curNode', null));
+            curNode = nodes.nodeList[curNode.key]
             $scope.txInfo = {
                 status: tx.blockNumber ? txStatus.mined : txStatus.found,
                 hash: tx.hash,
@@ -50,7 +55,10 @@ var txStatusCtrl = function($scope) {
                     eth: etherUnits.toEther(tx.gasPrice, 'wei')
                 },
                 data: tx.input == '0x' ? '' : tx.input,
-                nonce: new BigNumber(tx.nonce).toString()
+                nonce: new BigNumber(tx.nonce).toString(),
+                txExplorerUrl: curNode.blockExplorerTX.replace(/\[\[(\w+)\]\]/g, () => tx.hash),
+                fromExplorerUrl: curNode.blockExplorerAddr.replace(/\[\[(\w+)\]\]/g, () => tx.from),
+                toExplorerUrl: curNode.blockExplorerAddr.replace(/\[\[(\w+)\]\]/g, () => tx.to || '')
             }
             if ($scope.txInfo.status == txStatus.found) {
                 var _gasPrice = new BigNumber($scope.txInfo.gasPrice.wei).mul(1.1).floor();


### PR DESCRIPTION
On this page https://www.myetherwallet.com/#check-tx-status, all links lead to the Etherscan, regardless of the selected network. This PR resolves a problem with hardcoded links in template. Links to network explorers is taken from the list of nodes in the app/scripts/nodes.js file.