### PR TITLE
Update POA explorer links to BlockScout

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -254,8 +254,8 @@ nodes.nodeList = {
 	},
 	poa: {
 		name: "POA",
-		blockExplorerTX: "https://poaexplorer.com/tx/[[txHash]]",
-		blockExplorerAddr: "https://poaexplorer.com/address/[[address]]",
+		blockExplorerTX: "https://blockscout.com/poa/core/tx/[[txHash]]",
+		blockExplorerAddr: "https://blockscout.com/poa/core/address/[[address]]",
 		type: nodes.nodeTypes.POA,
 		eip155: true,
 		chainId: 99,


### PR DESCRIPTION
Closes https://github.com/kvhnuke/etherwallet/issues/2110

POA Network has been developing an open source EVM explorer called BlockScout. Many networks are currently available on BlockScout including POA, ETH, ETC, and many testnets. This PR replaces poaexplorer.com with blockscout.com for POA core network.