### PR TITLE
Added CryptoBonusMiles (CBM) token

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1056,6 +1056,12 @@
     "type": "default"
   },
   {
+    "address": "0x95efd1fe6099f65a7ed524def487483221094947",
+    "symbol": "CBM",
+    "decimal": 18,
+    "type": "default"
+  },
+  {
     "address": "0x076C97e1c869072eE22f8c91978C99B4bcB02591",
     "symbol": "CBT",
     "decimal": 18,


### PR DESCRIPTION
CryptoBonusMiles (CBM) token is a reward point token for Aeron (ARN) sub-project.

Functionality as described here: https://medium.com/@aeronaero/aeron-explains-cryptobonusmiles-a-universal-bonus-miles-platform-with-loyalty-multi-wallet-468cbfdb3366

website
https://cryptobonusmiles.com; https://aeron.aero
telegram
https://t.me/aeronaero
support email address
info@aeron.aero
