### PR TITLE
(Fix) Replace RPC provider endpoint for POA Network

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -263,8 +263,8 @@ nodes.nodeList = {
 		tokenList: require("./tokens/poaTokens.json"),
 		abiList: require("./abiDefinitions/poaAbi.json"),
 		estimateGas: true,
-		service: "poa.infura.io",
-		lib: new nodes.infuraNode("https://poa.infura.io")
+		service: "core.poa.network",
+		lib: new nodes.infuraNode("https://core.poa.network")
 	},
 	tomo: {
 		name: "TOMO",


### PR DESCRIPTION
Replace ~`poa.infura.io`~ with `core.poa.network` RPC provider endpoint for POA Network sidechain due to the future shutdown of Infura RPC provider URL for POA.

The list of RPC provider endpoints for POA Network: https://github.com/poanetwork/wiki#core-live
