### PR TITLE
Add DREAM Token to the List

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -1866,6 +1866,12 @@
     "type": "default"
   },
   {
+    "address": "0x82f4ded9cec9b5750fbff5c2185aee35afc16587",
+    "symbol": "DREAM",
+    "decimal": 6,
+    "type": "default"
+  },
+  {
     "address": "0x419c4db4b9e25d6db2ad9691ccb832c8d9fda05e",
     "symbol": "DRGN",
     "decimal": 18,


### PR DESCRIPTION
Hello!

We're DreamTeam - a young esports startup building things for gamers with Ethereum.

I've found [here](https://trello.com/c/tnxnTulT/61-erc20-support-information) that we can add our token by making a pull request to this repository. I've added our token info to `app/scripts/tokens/ethTokens.json`, preserving the existing sorting order.

More info about us:
- https://token.dreamteam.gg (token)
- https://dreamteam.gg (platform)
- https://dreamteam.gg/blog/ (blog)
- https://medium.com/dreamteam-gg (medium)
- https://etherscan.io/token/0x82f4ded9cec9b5750fbff5c2185aee35afc16587 (Etherscan)
- And many more

Please let me know is it enough for our token (display) support. Thank you!