### PR TITLE
bitbox: bump to firmware version 6.0.0

### DIFF
--- a/app/scripts/staticJS/digitalBitboxEth.js
+++ b/app/scripts/staticJS/digitalBitboxEth.js
@@ -22,7 +22,7 @@ var DigitalBitboxEth = function(comm, sec) {
     DigitalBitboxEth.to = setTimeout(function(){ DigitalBitboxEth.sec = ''; }, 60000);
 }
 
-var BitBoxSupportedMajorVersion = 5;
+var BitBoxSupportedMajorVersion = 6;
 
 DigitalBitboxEth.sec = '';
 DigitalBitboxEth.to = null;


### PR DESCRIPTION
No functional change related to MEW, but need to bump, otherwise upgraded users will get a warning that their firmware is not supported.